### PR TITLE
Using traits and types to define the behavior of the handshake

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -6,15 +6,14 @@
 use massa_signature::KeyPair;
 
 use crate::{
-    error::PeerNetError,
     handlers::MessageHandlers,
-    network_manager::{ActiveConnections, FallbackFunction, HandshakeFunction},
-    peer_id::PeerId,
-    transports::endpoint::Endpoint,
+    network_manager::FallbackFunction,
+    peer::HandshakeHandler,
 };
 
+
 /// Struct containing the configuration for the PeerNet manager.
-pub struct PeerNetConfiguration {
+pub struct PeerNetConfiguration<T: HandshakeHandler> {
     /// Number of peers we want to have in IN connection
     pub max_in_connections: usize,
     /// Number of peers we want to have in OUT connection
@@ -26,20 +25,20 @@ pub struct PeerNetConfiguration {
     pub message_handlers: MessageHandlers,
     /// Optional function to trigger at handshake
     /// (local keypair, endpoint to the peer, remote peer_id, active_connections)
-    pub handshake_function: Option<&'static HandshakeFunction>,
+    pub handshake_handler: T,
     /// Optional function to trigger when we receive a connection from a peer and we don't accept it
     pub fallback_function: Option<&'static FallbackFunction>,
 }
 
-impl Default for PeerNetConfiguration {
-    fn default() -> Self {
+impl<T: HandshakeHandler> PeerNetConfiguration<T> {
+    pub fn default(handshake_handler: T) -> Self {
         PeerNetConfiguration {
             max_in_connections: 0,
             max_out_connections: 0,
             self_keypair: KeyPair::generate(),
             message_handlers: MessageHandlers::default(),
-            handshake_function: None,
             fallback_function: None,
+            handshake_handler,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,12 +5,7 @@
 
 use massa_signature::KeyPair;
 
-use crate::{
-    handlers::MessageHandlers,
-    network_manager::FallbackFunction,
-    peer::HandshakeHandler,
-};
-
+use crate::{handlers::MessageHandlers, network_manager::FallbackFunction, peer::HandshakeHandler};
 
 /// Struct containing the configuration for the PeerNet manager.
 pub struct PeerNetConfiguration<T: HandshakeHandler> {

--- a/src/internal_handlers/peer_management/mod.rs
+++ b/src/internal_handlers/peer_management/mod.rs
@@ -248,8 +248,7 @@ pub fn handshake(
     listeners: &HashMap<SocketAddr, TransportType>,
     message_handlers: &MessageHandlers,
 ) -> Result<PeerId, PeerNetError> {
-    let mut bytes = (0 as u64).to_be_bytes().to_vec();
-    bytes.extend_from_slice(&PeerId::from_public_key(keypair.get_public_key()).to_bytes());
+    let mut bytes = PeerId::from_public_key(keypair.get_public_key()).to_bytes();
     //TODO: Add version in announce
     let listeners_announcement = Announcement::new(listeners.clone(), keypair).unwrap();
     bytes.extend_from_slice(&listeners_announcement.to_bytes());

--- a/src/internal_handlers/peer_management/mod.rs
+++ b/src/internal_handlers/peer_management/mod.rs
@@ -258,7 +258,7 @@ pub fn handshake(
     if received.is_empty() {
         return Err(PeerNetError::InvalidMessage);
     }
-    let mut offset = 8;
+    let mut offset = 0;
     //TODO: We use this to verify the signature before sending it to the handler.
     //This will be done also in the handler but as we are in the handshake we want to do it to invalid the handshake in case it fails.
     let peer_id = PeerId::from_bytes(&received[offset..offset + 32].try_into().unwrap())?;

--- a/src/internal_handlers/peer_management/tester.rs
+++ b/src/internal_handlers/peer_management/tester.rs
@@ -10,10 +10,15 @@ use crate::{
     internal_handlers::peer_management::{announcement::Announcement, PeerInfo},
     network_manager::PeerNetManager,
     peer_id::PeerId,
+    peer::HandshakeHandler,
     transports::{endpoint::Endpoint, OutConnectionConfig, TcpOutConnectionConfig, TransportType},
 };
 
 use super::{PeerDB, SharedPeerDB};
+
+#[derive(Clone)]
+pub struct EmptyHandshake;
+impl HandshakeHandler for EmptyHandshake {}
 
 pub struct Tester {
     handler: Option<JoinHandle<()>>,
@@ -26,8 +31,7 @@ impl Tester {
             let (_announcement_handle, announcement_handler) =
                 AnnouncementHandler::new(peer_db.clone());
             message_handlers.add_handler(0, MessageHandler::new(announcement_handler));
-            let mut config = PeerNetConfiguration::default();
-            config.handshake_function = Some(&empty_handshake);
+            let mut config = PeerNetConfiguration::default(EmptyHandshake {});
             config.fallback_function = Some(&empty_fallback);
             config.max_out_connections = 1;
             config.message_handlers = message_handlers;
@@ -80,17 +84,6 @@ impl AnnouncementHandler {
             sender,
         )
     }
-}
-
-pub fn empty_handshake(
-    keypair: &KeyPair,
-    _endpoint: &mut Endpoint,
-    _listeners: &HashMap<SocketAddr, TransportType>,
-    _message_handlers: &MessageHandlers,
-) -> Result<PeerId, PeerNetError> {
-    //endpoint.receive()?;
-    //ADd peer db
-    Ok(PeerId::from_public_key(keypair.get_public_key()))
 }
 
 pub fn empty_fallback(

--- a/src/internal_handlers/peer_management/tester.rs
+++ b/src/internal_handlers/peer_management/tester.rs
@@ -9,8 +9,8 @@ use crate::{
     handlers::{MessageHandler, MessageHandlers},
     internal_handlers::peer_management::{announcement::Announcement, PeerInfo},
     network_manager::PeerNetManager,
-    peer_id::PeerId,
     peer::HandshakeHandler,
+    peer_id::PeerId,
     transports::{endpoint::Endpoint, OutConnectionConfig, TcpOutConnectionConfig, TransportType},
 };
 

--- a/src/internal_handlers/peer_management/tester.rs
+++ b/src/internal_handlers/peer_management/tester.rs
@@ -24,22 +24,21 @@ pub struct EmptyHandshake {
 impl HandshakeHandler for EmptyHandshake {
     fn perform_handshake(
         &mut self,
-        keypair: &KeyPair,
+        _: &KeyPair,
         endpoint: &mut Endpoint,
         _: &HashMap<SocketAddr, TransportType>,
         _: &MessageHandlers,
     ) -> Result<PeerId, PeerNetError> {
-        let id = PeerId::from_public_key(keypair.get_public_key());
         let data = endpoint.receive()?;
         let peer_id = PeerId::from_bytes(&data[..32].try_into().unwrap())?;
         let announcement = Announcement::from_bytes(&data[32..], &peer_id)?;
         self.peer_db.write().peers.insert(
-            peer_id,
+            peer_id.clone(),
             PeerInfo {
                 last_announce: announcement,
             },
         );
-        Ok(id)
+        Ok(peer_id)
     }
 }
 

--- a/src/network_manager.rs
+++ b/src/network_manager.rs
@@ -11,7 +11,7 @@ use crate::{
     config::PeerNetConfiguration,
     error::PeerNetError,
     handlers::MessageHandlers,
-    peer::PeerConnection,
+    peer::{PeerConnection, HandshakeHandler},
     peer_id::PeerId,
     transports::{
         endpoint::Endpoint, InternalTransportType, OutConnectionConfig, Transport, TransportType,
@@ -47,18 +47,18 @@ pub type HandshakeFunction = dyn Fn(
 pub(crate) type SharedActiveConnections = Arc<RwLock<ActiveConnections>>;
 
 /// Main structure of the PeerNet library used to manage the transports and the peers.
-pub struct PeerNetManager {
-    pub config: PeerNetConfiguration,
+pub struct PeerNetManager<T: HandshakeHandler> {
+    pub config: PeerNetConfiguration<T>,
     pub active_connections: SharedActiveConnections,
-    handshake_function: Option<&'static HandshakeFunction>,
+    handshake_handler: T,
     fallback_function: Option<&'static FallbackFunction>,
     self_keypair: KeyPair,
     transports: HashMap<TransportType, InternalTransportType>,
 }
 
-impl PeerNetManager {
+impl<T: HandshakeHandler> PeerNetManager<T> {
     /// Creates a new PeerNetManager. Initializes a new database of peers and have no transports by default.
-    pub fn new(config: PeerNetConfiguration) -> PeerNetManager {
+    pub fn new(config: PeerNetConfiguration<T>) -> PeerNetManager<T> {
         let self_keypair = config.self_keypair.clone();
         let active_connections = Arc::new(RwLock::new(ActiveConnections {
             nb_in_connections: 0,
@@ -69,7 +69,7 @@ impl PeerNetManager {
             listeners: Default::default(),
         }));
         PeerNetManager {
-            handshake_function: config.handshake_function.clone(),
+            handshake_handler: config.handshake_handler.clone(),
             fallback_function: config.fallback_function.clone(),
             config,
             self_keypair,
@@ -89,12 +89,11 @@ impl PeerNetManager {
             InternalTransportType::from_transport_type(
                 transport_type,
                 self.active_connections.clone(),
-                self.handshake_function.clone(),
                 self.fallback_function.clone(),
                 self.config.message_handlers.clone(),
             )
         });
-        transport.start_listener(self.self_keypair.clone(), addr)?;
+        transport.start_listener(self.self_keypair.clone(), addr, self.handshake_handler.clone())?;
         Ok(())
     }
 
@@ -109,7 +108,6 @@ impl PeerNetManager {
             InternalTransportType::from_transport_type(
                 transport_type,
                 self.active_connections.clone(),
-                self.handshake_function.clone(),
                 self.fallback_function.clone(),
                 self.config.message_handlers.clone(),
             )
@@ -136,7 +134,6 @@ impl PeerNetManager {
                 InternalTransportType::from_transport_type(
                     TransportType::from_out_connection_config(&out_connection_config),
                     self.active_connections.clone(),
-                    self.handshake_function.clone(),
                     self.fallback_function.clone(),
                     self.config.message_handlers.clone(),
                 )
@@ -146,6 +143,7 @@ impl PeerNetManager {
             addr,
             timeout,
             out_connection_config.into(),
+            self.handshake_handler.clone(),
         )?;
         Ok(())
     }
@@ -156,7 +154,7 @@ impl PeerNetManager {
     }
 }
 
-impl Drop for PeerNetManager {
+impl<T: HandshakeHandler> Drop for PeerNetManager<T> {
     fn drop(&mut self) {
         {
             let mut active_connections = self.active_connections.write();

--- a/src/network_manager.rs
+++ b/src/network_manager.rs
@@ -11,7 +11,7 @@ use crate::{
     config::PeerNetConfiguration,
     error::PeerNetError,
     handlers::MessageHandlers,
-    peer::{PeerConnection, HandshakeHandler},
+    peer::{HandshakeHandler, PeerConnection},
     peer_id::PeerId,
     transports::{
         endpoint::Endpoint, InternalTransportType, OutConnectionConfig, Transport, TransportType,
@@ -93,7 +93,11 @@ impl<T: HandshakeHandler> PeerNetManager<T> {
                 self.config.message_handlers.clone(),
             )
         });
-        transport.start_listener(self.self_keypair.clone(), addr, self.handshake_handler.clone())?;
+        transport.start_listener(
+            self.self_keypair.clone(),
+            addr,
+            self.handshake_handler.clone(),
+        )?;
         Ok(())
     }
 

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -1,19 +1,35 @@
 //! Every information about a peer (not used for now)
 
-use std::{fmt::Debug, net::SocketAddr, thread::spawn, time::Duration};
+use std::{fmt::Debug, net::SocketAddr, thread::spawn};
+use std::collections::HashMap;
 
 use crossbeam::{
-    channel::{unbounded, RecvTimeoutError, Sender, TryRecvError},
+    channel::{unbounded, Sender, TryRecvError},
     select,
 };
 use massa_signature::KeyPair;
 
 use crate::{
     error::PeerNetError,
+    peer_id::PeerId,
     handlers::MessageHandlers,
-    network_manager::{HandshakeFunction, SharedActiveConnections},
-    transports::{endpoint::Endpoint, InternalTransportType},
+    network_manager::SharedActiveConnections,
+    transports::{endpoint::Endpoint, TransportType},
 };
+
+pub trait HandshakeHandler : Send + Clone + 'static {
+    fn perform_handshake(&mut self, keypair: &KeyPair, endpoint: &mut Endpoint, listeners: &HashMap<SocketAddr, TransportType>, handlers: &MessageHandlers) -> Result<PeerId, PeerNetError> {
+        endpoint.handshake(&keypair)
+    }
+}
+
+#[derive(Clone)]
+pub struct EmptyHandshake;
+impl HandshakeHandler for EmptyHandshake {
+    fn perform_handshake(&mut self, keypair: &KeyPair, endpoint: &mut Endpoint, listeners: &HashMap<SocketAddr, TransportType>, handlers: &MessageHandlers) -> Result<PeerId, PeerNetError> {
+        Ok(PeerId::from_public_key(keypair.get_public_key()))
+    }
+}
 
 pub struct SendChannels {
     low_priority: Sender<Vec<u8>>,
@@ -67,10 +83,10 @@ impl Debug for PeerConnection {
     }
 }
 
-pub(crate) fn new_peer(
+pub(crate) fn new_peer<T: HandshakeHandler>(
     self_keypair: KeyPair,
     mut endpoint: Endpoint,
-    handshake_function: Option<&'static HandshakeFunction>,
+    mut handshake_handler: T,
     message_handlers: MessageHandlers,
     active_connections: SharedActiveConnections,
 ) {
@@ -81,17 +97,7 @@ pub(crate) fn new_peer(
             active_connections.listeners.clone()
         };
         //HANDSHAKE
-        let peer_id = if let Some(handshake_function) = handshake_function {
-            match handshake_function(&self_keypair, &mut endpoint, &listeners, &message_handlers) {
-                Ok(peer_id) => peer_id,
-                Err(err) => {
-                    println!("Handshake error: {:#?}", err);
-                    return;
-                }
-            }
-        } else {
-            endpoint.handshake(&self_keypair).unwrap()
-        };
+        let peer_id = handshake_handler.perform_handshake(&self_keypair, &mut endpoint, &listeners, &message_handlers).unwrap();
 
         //TODO: Bounded
 

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -1,7 +1,7 @@
 //! Every information about a peer (not used for now)
 
-use std::{fmt::Debug, net::SocketAddr, thread::spawn};
 use std::collections::HashMap;
+use std::{fmt::Debug, net::SocketAddr, thread::spawn};
 
 use crossbeam::{
     channel::{unbounded, Sender, TryRecvError},
@@ -11,23 +11,21 @@ use massa_signature::KeyPair;
 
 use crate::{
     error::PeerNetError,
-    peer_id::PeerId,
     handlers::MessageHandlers,
     network_manager::SharedActiveConnections,
+    peer_id::PeerId,
     transports::{endpoint::Endpoint, TransportType},
 };
 
-pub trait HandshakeHandler : Send + Clone + 'static {
-    fn perform_handshake(&mut self, keypair: &KeyPair, endpoint: &mut Endpoint, listeners: &HashMap<SocketAddr, TransportType>, handlers: &MessageHandlers) -> Result<PeerId, PeerNetError> {
+pub trait HandshakeHandler: Send + Clone + 'static {
+    fn perform_handshake(
+        &mut self,
+        keypair: &KeyPair,
+        endpoint: &mut Endpoint,
+        listeners: &HashMap<SocketAddr, TransportType>,
+        handlers: &MessageHandlers,
+    ) -> Result<PeerId, PeerNetError> {
         endpoint.handshake(&keypair)
-    }
-}
-
-#[derive(Clone)]
-pub struct EmptyHandshake;
-impl HandshakeHandler for EmptyHandshake {
-    fn perform_handshake(&mut self, keypair: &KeyPair, endpoint: &mut Endpoint, listeners: &HashMap<SocketAddr, TransportType>, handlers: &MessageHandlers) -> Result<PeerId, PeerNetError> {
-        Ok(PeerId::from_public_key(keypair.get_public_key()))
     }
 }
 
@@ -97,7 +95,9 @@ pub(crate) fn new_peer<T: HandshakeHandler>(
             active_connections.listeners.clone()
         };
         //HANDSHAKE
-        let peer_id = handshake_handler.perform_handshake(&self_keypair, &mut endpoint, &listeners, &message_handlers).unwrap();
+        let peer_id = handshake_handler
+            .perform_handshake(&self_keypair, &mut endpoint, &listeners, &message_handlers)
+            .unwrap();
 
         //TODO: Bounded
 

--- a/src/transports/mod.rs
+++ b/src/transports/mod.rs
@@ -10,8 +10,8 @@ use crate::{
     network_manager::{
         ActiveConnections, FallbackFunction, HandshakeFunction, SharedActiveConnections,
     },
-    peer_id::PeerId,
     peer::HandshakeHandler,
+    peer_id::PeerId,
 };
 
 use self::{endpoint::Endpoint, quic::QuicTransport, tcp::TcpTransport};

--- a/src/transports/quic.rs
+++ b/src/transports/quic.rs
@@ -348,7 +348,11 @@ impl Transport for QuicTransport {
                 .get(&config.local_addr)
                 .expect("Listener not found")
         } else {
-            self.start_listener(self_keypair.clone(), config.local_addr, handshake_handler.clone())?;
+            self.start_listener(
+                self_keypair.clone(),
+                config.local_addr,
+                handshake_handler.clone(),
+            )?;
             //TODO: Make things more elegant with waker etc
             std::thread::sleep(Duration::from_millis(100));
             self.listeners

--- a/src/transports/quic.rs
+++ b/src/transports/quic.rs
@@ -15,7 +15,7 @@ use crate::{
     error::PeerNetError,
     handlers::MessageHandlers,
     network_manager::{FallbackFunction, HandshakeFunction, SharedActiveConnections},
-    peer::new_peer,
+    peer::{new_peer, HandshakeHandler},
     peer_id::PeerId,
     transports::Endpoint,
 };
@@ -27,7 +27,6 @@ const STOP_LISTENER: Token = Token(10);
 
 pub(crate) struct QuicTransport {
     pub active_connections: SharedActiveConnections,
-    pub handshake_function: Option<&'static HandshakeFunction>,
     pub fallback_function: Option<&'static FallbackFunction>,
     pub message_handlers: MessageHandlers,
     pub out_connection_attempts: WaitGroup,
@@ -77,13 +76,11 @@ pub struct QuicOutConnectionConfig {
 impl QuicTransport {
     pub fn new(
         active_connections: SharedActiveConnections,
-        handshake_function: Option<&'static HandshakeFunction>,
         fallback_function: Option<&'static FallbackFunction>,
         message_handlers: MessageHandlers,
     ) -> QuicTransport {
         QuicTransport {
             out_connection_attempts: WaitGroup::new(),
-            handshake_function,
             fallback_function,
             listeners: Default::default(),
             connections: Arc::new(RwLock::new(HashMap::new())),
@@ -98,10 +95,11 @@ impl Transport for QuicTransport {
 
     type Endpoint = QuicEndpoint;
 
-    fn start_listener(
+    fn start_listener<T: HandshakeHandler>(
         &mut self,
         self_keypair: KeyPair,
         address: SocketAddr,
+        handshake_handler: T,
     ) -> Result<(), PeerNetError> {
         let mut poll = Poll::new().map_err(|err| PeerNetError::ListenerError(err.to_string()))?;
         //TODO: Configurable capacity
@@ -128,7 +126,6 @@ impl Transport for QuicTransport {
         let listener_handle = std::thread::spawn({
             let active_connections = self.active_connections.clone();
             let message_handlers = self.message_handlers.clone();
-            let handshake_function = self.handshake_function.clone();
             let fallback_function = self.fallback_function.clone();
             let server = server.try_clone().unwrap();
             move || {
@@ -228,7 +225,7 @@ impl Transport for QuicTransport {
                                                 data_receiver: recv_rx,
                                                 data_sender: send_tx,
                                             }),
-                                            handshake_function.clone(),
+                                            handshake_handler.clone(),
                                             message_handlers.clone(),
                                             active_connections.clone(),
                                         );
@@ -335,12 +332,13 @@ impl Transport for QuicTransport {
         Ok(())
     }
 
-    fn try_connect(
+    fn try_connect<T: HandshakeHandler>(
         &mut self,
         self_keypair: KeyPair,
         address: SocketAddr,
         _timeout: Duration,
         config: &Self::OutConnectionConfig,
+        handshake_handler: T,
     ) -> Result<(), PeerNetError> {
         //TODO: Use timeout
         let config = config.clone();
@@ -350,7 +348,7 @@ impl Transport for QuicTransport {
                 .get(&config.local_addr)
                 .expect("Listener not found")
         } else {
-            self.start_listener(self_keypair.clone(), config.local_addr)?;
+            self.start_listener(self_keypair.clone(), config.local_addr, handshake_handler.clone())?;
             //TODO: Make things more elegant with waker etc
             std::thread::sleep(Duration::from_millis(100));
             self.listeners
@@ -362,7 +360,6 @@ impl Transport for QuicTransport {
             let active_connections = self.active_connections.clone();
             let message_handlers = self.message_handlers.clone();
             let wg = self.out_connection_attempts.clone();
-            let handshake_function = self.handshake_function.clone();
             move || {
                 let mut out = [0; 65507];
                 println!("Connecting to {}", address);
@@ -428,7 +425,7 @@ impl Transport for QuicTransport {
                         data_receiver: recv_rx,
                         data_sender: send_tx,
                     }),
-                    handshake_function.clone(),
+                    handshake_handler.clone(),
                     message_handlers.clone(),
                     active_connections.clone(),
                 );

--- a/src/transports/tcp.rs
+++ b/src/transports/tcp.rs
@@ -78,7 +78,7 @@ impl Transport for TcpTransport {
         &mut self,
         self_keypair: KeyPair,
         address: SocketAddr,
-        handshake_handler: T
+        handshake_handler: T,
     ) -> Result<(), PeerNetError> {
         let mut poll = Poll::new().map_err(|err| PeerNetError::ListenerError(err.to_string()))?;
         let mut events = Events::with_capacity(128);

--- a/tests/handlers.rs
+++ b/tests/handlers.rs
@@ -10,9 +10,14 @@ use peernet::{
     },
     network_manager::PeerNetManager,
     peer_id::PeerId,
+    peer::HandshakeHandler,
     transports::{OutConnectionConfig, TcpOutConnectionConfig, TransportType},
 };
 use util::create_basic_handler;
+
+#[derive(Clone)]
+struct EmptyHandshake;
+impl HandshakeHandler for EmptyHandshake {}
 
 #[test]
 fn two_peers_tcp_with_one_handler() {
@@ -35,7 +40,7 @@ fn two_peers_tcp_with_one_handler() {
         max_in_connections: 10,
         max_out_connections: 20,
         self_keypair: keypair1.clone(),
-        handshake_function: None,
+        handshake_handler: EmptyHandshake {},
         fallback_function: None,
         message_handlers: message_handlers.clone(),
     };
@@ -48,7 +53,7 @@ fn two_peers_tcp_with_one_handler() {
         max_in_connections: 10,
         max_out_connections: 20,
         self_keypair: keypair2.clone(),
-        handshake_function: None,
+        handshake_handler: EmptyHandshake {},
         fallback_function: None,
         message_handlers,
     };
@@ -90,7 +95,7 @@ fn two_peers_tcp_with_peer_management_handler() {
         max_in_connections: 10,
         max_out_connections: 20,
         self_keypair: keypair1.clone(),
-        handshake_function: Some(&handshake),
+        handshake_handler: EmptyHandshake {},
         fallback_function: Some(&fallback_function),
         message_handlers: message_handlers.clone(),
     };
@@ -113,7 +118,7 @@ fn two_peers_tcp_with_peer_management_handler() {
         max_in_connections: 10,
         max_out_connections: 20,
         self_keypair: keypair2.clone(),
-        handshake_function: Some(&handshake),
+        handshake_handler: EmptyHandshake {},
         fallback_function: Some(&fallback_function),
         message_handlers,
     };

--- a/tests/handlers.rs
+++ b/tests/handlers.rs
@@ -9,8 +9,8 @@ use peernet::{
         fallback_function, handshake, InitialPeers, PeerManagementHandler,
     },
     network_manager::PeerNetManager,
-    peer_id::PeerId,
     peer::HandshakeHandler,
+    peer_id::PeerId,
     transports::{OutConnectionConfig, TcpOutConnectionConfig, TransportType},
 };
 use util::create_basic_handler;

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -5,8 +5,8 @@ use massa_signature::KeyPair;
 use peernet::{
     config::PeerNetConfiguration,
     network_manager::PeerNetManager,
-    peer_id::PeerId,
     peer::HandshakeHandler,
+    peer_id::PeerId,
     transports::{
         OutConnectionConfig, QuicOutConnectionConfig, TcpOutConnectionConfig, TransportType,
     },

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -14,8 +14,8 @@ use peernet::{
 use util::create_clients;
 
 #[derive(Clone)]
-pub struct EmptyHandshake;
-impl HandshakeHandler for EmptyHandshake {}
+pub struct DefaultHandshake;
+impl HandshakeHandler for DefaultHandshake {}
 
 #[test]
 fn simple() {
@@ -26,7 +26,7 @@ fn simple() {
         self_keypair: keypair.clone(),
         fallback_function: None,
         message_handlers: Default::default(),
-        handshake_handler: EmptyHandshake,
+        handshake_handler: DefaultHandshake,
     };
     let mut manager = PeerNetManager::new(config);
     manager
@@ -54,7 +54,7 @@ fn two_peers_tcp() {
         max_in_connections: 10,
         max_out_connections: 20,
         self_keypair: keypair1.clone(),
-        handshake_handler: EmptyHandshake {},
+        handshake_handler: DefaultHandshake {},
         fallback_function: None,
         message_handlers: Default::default(),
     };
@@ -70,7 +70,7 @@ fn two_peers_tcp() {
         self_keypair: keypair2.clone(),
         fallback_function: None,
         message_handlers: Default::default(),
-        handshake_handler: EmptyHandshake {},
+        handshake_handler: DefaultHandshake {},
     };
     let mut manager2 = PeerNetManager::new(config);
     manager2
@@ -96,7 +96,7 @@ fn two_peers_quic() {
         self_keypair: keypair1.clone(),
         fallback_function: None,
         message_handlers: Default::default(),
-        handshake_handler: EmptyHandshake {},
+        handshake_handler: DefaultHandshake {},
     };
     let mut manager = PeerNetManager::new(config);
     manager
@@ -110,7 +110,7 @@ fn two_peers_quic() {
         self_keypair: keypair2.clone(),
         fallback_function: None,
         message_handlers: Default::default(),
-        handshake_handler: EmptyHandshake {},
+        handshake_handler: DefaultHandshake {},
     };
     let mut manager2 = PeerNetManager::new(config);
     manager2

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -6,11 +6,16 @@ use peernet::{
     config::PeerNetConfiguration,
     network_manager::PeerNetManager,
     peer_id::PeerId,
+    peer::HandshakeHandler,
     transports::{
         OutConnectionConfig, QuicOutConnectionConfig, TcpOutConnectionConfig, TransportType,
     },
 };
 use util::create_clients;
+
+#[derive(Clone)]
+pub struct EmptyHandshake;
+impl HandshakeHandler for EmptyHandshake {}
 
 #[test]
 fn simple() {
@@ -19,9 +24,9 @@ fn simple() {
         max_in_connections: 10,
         max_out_connections: 20,
         self_keypair: keypair.clone(),
-        handshake_function: None,
         fallback_function: None,
         message_handlers: Default::default(),
+        handshake_handler: EmptyHandshake,
     };
     let mut manager = PeerNetManager::new(config);
     manager
@@ -49,7 +54,7 @@ fn two_peers_tcp() {
         max_in_connections: 10,
         max_out_connections: 20,
         self_keypair: keypair1.clone(),
-        handshake_function: None,
+        handshake_handler: EmptyHandshake {},
         fallback_function: None,
         message_handlers: Default::default(),
     };
@@ -63,9 +68,9 @@ fn two_peers_tcp() {
         max_in_connections: 10,
         max_out_connections: 20,
         self_keypair: keypair2.clone(),
-        handshake_function: None,
         fallback_function: None,
         message_handlers: Default::default(),
+        handshake_handler: EmptyHandshake {},
     };
     let mut manager2 = PeerNetManager::new(config);
     manager2
@@ -89,9 +94,9 @@ fn two_peers_quic() {
         max_in_connections: 10,
         max_out_connections: 20,
         self_keypair: keypair1.clone(),
-        handshake_function: None,
         fallback_function: None,
         message_handlers: Default::default(),
+        handshake_handler: EmptyHandshake {},
     };
     let mut manager = PeerNetManager::new(config);
     manager
@@ -103,9 +108,9 @@ fn two_peers_quic() {
         max_in_connections: 10,
         max_out_connections: 20,
         self_keypair: keypair2.clone(),
-        handshake_function: None,
         fallback_function: None,
         message_handlers: Default::default(),
+        handshake_handler: EmptyHandshake {},
     };
     let mut manager2 = PeerNetManager::new(config);
     manager2


### PR DESCRIPTION
Instead of registering an override for the handshake at runtime, pass a generic type to the `PeerNetConfiguration` that implements a trait `HanshakeHandler`.

This trait has one function `perform_handshake`, that has a default implementation.

As the struct requires `Clone` to be passed around in threads (and so should be tiny structs), the minimal implementation is:
``` rust
#[derive(Clone)]
struct EmptyHandshake;
impl HandshakeHandler for EmptyHandshake {}
```

Compared to the previous implementation, a handler MUST be passed to the configuration.