### PR TITLE
Use stream_limiter::Limiter to implement rate limit on TCP streams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,6 +521,7 @@ dependencies = [
  "quiche",
  "rand 0.8.5",
  "serde",
+ "stream_limiter",
 ]
 
 [[package]]
@@ -724,6 +725,11 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "stream_limiter"
+version = "1.0.0"
+source = "git+https://github.com/massalabs/stream_limiter#17dbc6efb47d6a46ad6540d56d81a70c1a9d68b0"
 
 [[package]]
 name = "subtle"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -728,8 +728,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "stream_limiter"
-version = "1.0.0"
-source = "git+https://github.com/massalabs/stream_limiter#17dbc6efb47d6a46ad6540d56d81a70c1a9d68b0"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2182c38ed520c8c7b2fcbadef2ef7c74bcc2767b09a4f1edc8f021400e40cca"
 
 [[package]]
 name = "subtle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ mio = { version = "0.8", features = ["os-poll", "net"] }
 massa_hash = { git = "https://github.com/massalabs/massa", package = "massa_hash" }
 massa_signature = { git = "https://github.com/massalabs/massa", package = "massa_signature" }
 serde = { version = "1.0", features = ["derive"] }
+stream_limiter = { git = "https://github.com/massalabs/stream_limiter" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ mio = { version = "0.8", features = ["os-poll", "net"] }
 massa_hash = { git = "https://github.com/massalabs/massa", package = "massa_hash" }
 massa_signature = { git = "https://github.com/massalabs/massa", package = "massa_signature" }
 serde = { version = "1.0", features = ["derive"] }
-stream_limiter = { git = "https://github.com/massalabs/stream_limiter" }
+stream_limiter = "1.1.0"

--- a/src/transports/tcp.rs
+++ b/src/transports/tcp.rs
@@ -17,6 +17,7 @@ use crate::types::KeyPair;
 use crossbeam::sync::WaitGroup;
 use mio::net::TcpListener as MioTcpListener;
 use mio::{Events, Interest, Poll, Token, Waker};
+use stream_limiter::Limiter;
 
 pub(crate) struct TcpTransport {
     pub active_connections: SharedActiveConnections,
@@ -28,6 +29,7 @@ pub(crate) struct TcpTransport {
 
 const NEW_CONNECTION: Token = Token(0);
 const STOP_LISTENER: Token = Token(10);
+const RATE_LIMIT: u128 = 10 * 1024;
 
 #[derive(Clone)]
 pub struct TcpOutConnectionConfig;
@@ -35,21 +37,25 @@ pub struct TcpOutConnectionConfig;
 //TODO: IN/OUT different types because TCP ports are not reliable
 pub struct TcpEndpoint {
     pub address: SocketAddr,
-    pub stream: TcpStream,
+    pub stream: Limiter<TcpStream>,
 }
 
 impl Clone for TcpEndpoint {
     fn clone(&self) -> Self {
         TcpEndpoint {
             address: self.address,
-            stream: self.stream.try_clone().unwrap(),
+            stream: Limiter::new(
+                self.stream.stream.try_clone().unwrap(),
+                RATE_LIMIT,
+                Duration::from_secs(1),
+            ),
         }
     }
 }
 
 impl TcpEndpoint {
     pub fn shutdown(&mut self) {
-        let _ = self.stream.shutdown(std::net::Shutdown::Both);
+        let _ = self.stream.stream.shutdown(std::net::Shutdown::Both);
     }
 }
 
@@ -109,9 +115,15 @@ impl Transport for TcpTransport {
                         match event.token() {
                             NEW_CONNECTION => {
                                 //TODO: Error handling
-                                //TODO: Use rate limiting
                                 let (stream, address) = server.accept().unwrap();
-                                let mut endpoint = Endpoint::Tcp(TcpEndpoint { address, stream });
+                                let mut endpoint = Endpoint::Tcp(TcpEndpoint {
+                                    address,
+                                    stream: Limiter::new(
+                                        stream,
+                                        RATE_LIMIT,
+                                        Duration::from_secs(1),
+                                    ),
+                                });
                                 {
                                     let mut active_connections = active_connections.write();
                                     if active_connections.nb_in_connections
@@ -173,10 +185,10 @@ impl Transport for TcpTransport {
             let wg = self.out_connection_attempts.clone();
             let message_handlers = self.message_handlers.clone();
             move || {
-                //TODO: Rate limiting
                 let Ok(stream) = TcpStream::connect_timeout(&address, timeout) else {
-                return;
+                    return;
                 };
+                let stream = Limiter::new(stream, RATE_LIMIT, Duration::from_secs(1));
                 println!("Connected to {}", address);
 
                 {
@@ -224,7 +236,6 @@ impl Transport for TcpTransport {
     }
 
     fn send(endpoint: &mut Self::Endpoint, data: &[u8]) -> Result<(), PeerNetError> {
-        //TODO: Rate limiting
         endpoint
             .stream
             .write(&data.len().to_le_bytes())
@@ -237,7 +248,6 @@ impl Transport for TcpTransport {
     }
 
     fn receive(endpoint: &mut Self::Endpoint) -> Result<Vec<u8>, PeerNetError> {
-        //TODO: Rate limiting
         let mut len_bytes = [0u8; 8];
         endpoint
             .stream


### PR DESCRIPTION
Implements #17 

In order to adapt it for the usage, I had to set the `stream` attribute to `pub` in `stream_limiter` as it's required in order to perform `try_clone` or `shutdown` methods on it.

As the change are not published on crates.io yet, I set up the git repository in `Cargo.toml`, which is something to do before merging this PR.