### PR TITLE
Protect against multiple TCP connections from same IP

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -23,6 +23,8 @@ pub struct PeerNetConfiguration<T: HandshakeHandler> {
     pub handshake_handler: T,
     /// Optional function to trigger when we receive a connection from a peer and we don't accept it
     pub fallback_function: Option<&'static FallbackFunction>,
+    /// Optional features to enable for the manager
+    pub optionnal_features: PeerNetFeatures,
 }
 
 impl<T: HandshakeHandler> PeerNetConfiguration<T> {
@@ -34,6 +36,26 @@ impl<T: HandshakeHandler> PeerNetConfiguration<T> {
             message_handlers: MessageHandlers::default(),
             fallback_function: None,
             handshake_handler,
+            optionnal_features: PeerNetFeatures::default(),
         }
+    }
+}
+
+#[derive(Clone)]
+pub struct PeerNetFeatures {
+    pub reject_same_ip_addr: bool,
+}
+
+impl Default for PeerNetFeatures {
+    fn default() -> PeerNetFeatures {
+        PeerNetFeatures {
+            reject_same_ip_addr: true
+        }
+    }
+}
+
+impl PeerNetFeatures {
+    pub fn set_reject_same_ip_addr(self, val: bool) -> PeerNetFeatures {
+        PeerNetFeatures { reject_same_ip_addr: val, ..self }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,7 +36,7 @@ impl<T: HandshakeHandler> PeerNetConfiguration<T> {
             message_handlers: MessageHandlers::default(),
             fallback_function: None,
             handshake_handler,
-            optionnal_features: PeerNetFeatures::default(),
+            optional_features: PeerNetFeatures::default(),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -56,6 +56,10 @@ impl Default for PeerNetFeatures {
 
 impl PeerNetFeatures {
     #[allow(clippy::needless_update)]
+    // Built this way instead of a mutable reference to allow setting
+    //  a default config with only a specific feature enabled / disabled
+    //      (ex: PeerNetFeatures::default().set_reject_same_ip_addr(false))
+    /// Set the IP address spoofing rejection
     pub fn set_reject_same_ip_addr(self, val: bool) -> PeerNetFeatures {
         PeerNetFeatures {
             reject_same_ip_addr: val,

--- a/src/config.rs
+++ b/src/config.rs
@@ -49,13 +49,17 @@ pub struct PeerNetFeatures {
 impl Default for PeerNetFeatures {
     fn default() -> PeerNetFeatures {
         PeerNetFeatures {
-            reject_same_ip_addr: true
+            reject_same_ip_addr: true,
         }
     }
 }
 
 impl PeerNetFeatures {
+    #[allow(clippy::needless_update)]
     pub fn set_reject_same_ip_addr(self, val: bool) -> PeerNetFeatures {
-        PeerNetFeatures { reject_same_ip_addr: val, ..self }
+        PeerNetFeatures {
+            reject_same_ip_addr: val,
+            ..self
+        }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,7 +24,7 @@ pub struct PeerNetConfiguration<T: HandshakeHandler> {
     /// Optional function to trigger when we receive a connection from a peer and we don't accept it
     pub fallback_function: Option<&'static FallbackFunction>,
     /// Optional features to enable for the manager
-    pub optionnal_features: PeerNetFeatures,
+    pub optional_features: PeerNetFeatures,
 }
 
 impl<T: HandshakeHandler> PeerNetConfiguration<T> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //!
 //! use peernet::types::KeyPair;
 //! use peernet::{
-//!    config::PeerNetConfiguration,
+//!    config::{PeerNetConfiguration, PeerNetFeatures},
 //!    network_manager::PeerNetManager,
 //!    peer_id::PeerId,
 //!    transports::{OutConnectionConfig, TcpOutConnectionConfig, QuicOutConnectionConfig, TransportType},
@@ -28,6 +28,7 @@
 //!     message_handlers: Default::default(),
 //!     fallback_function: None,
 //!     handshake_handler: DefaultHandshake,
+//!     optional_features: PeerNetFeatures::default(),
 //! };
 //! // Setup the manager for the first peer
 //! let mut manager = PeerNetManager::new(config);
@@ -46,6 +47,7 @@
 //!     message_handlers: Default::default(),
 //!     fallback_function: None,
 //!     handshake_handler: DefaultHandshake,
+//!     optional_features: PeerNetFeatures::default(),
 //! };
 //! // Setup the manager for the second peer
 //! let mut manager2 = PeerNetManager::new(config);

--- a/src/network_manager.rs
+++ b/src/network_manager.rs
@@ -29,6 +29,21 @@ pub struct ActiveConnections {
     pub connections: HashMap<PeerId, PeerConnection>,
     pub listeners: HashMap<SocketAddr, TransportType>,
 }
+
+impl ActiveConnections {
+    /// Check if an address has to be refused or not
+    pub fn check_addr_accepted(&self, addr: &SocketAddr) -> bool {
+        if self.connections.is_empty() {
+            true
+        } else {
+            !self
+                .connections
+                .iter()
+                .any(|(_, connection)| connection.endpoint.get_target_addr().ip() != addr.ip())
+        }
+    }
+}
+
 // Send some data to a peer that we didn't accept his connection
 pub type FallbackFunction = dyn Fn(
         &KeyPair,

--- a/src/network_manager.rs
+++ b/src/network_manager.rs
@@ -39,7 +39,7 @@ impl ActiveConnections {
             !self
                 .connections
                 .iter()
-                .any(|(_, connection)| connection.endpoint.get_target_addr().ip() != addr.ip())
+                .any(|(_, connection)| connection.endpoint.get_target_addr().ip() == addr.ip())
         }
     }
 }

--- a/src/network_manager.rs
+++ b/src/network_manager.rs
@@ -31,7 +31,7 @@ pub struct ActiveConnections {
 }
 
 impl ActiveConnections {
-    /// Check if an address has to be refused or not
+    /// Check if a new connection from a specific address can be accepted or not
     pub fn check_addr_accepted(&self, addr: &SocketAddr) -> bool {
         if self.connections.is_empty() {
             true

--- a/src/network_manager.rs
+++ b/src/network_manager.rs
@@ -134,7 +134,7 @@ impl<T: HandshakeHandler> PeerNetManager<T> {
                 self.active_connections.clone(),
                 self.fallback_function,
                 self.config.message_handlers.clone(),
-                self.config.optionnal_features.clone(),
+                self.config.optional_features.clone(),
             )
         });
         transport.start_listener(
@@ -158,7 +158,7 @@ impl<T: HandshakeHandler> PeerNetManager<T> {
                 self.active_connections.clone(),
                 self.fallback_function,
                 self.config.message_handlers.clone(),
-                self.config.optionnal_features.clone(),
+                self.config.optional_features.clone(),
             )
         });
         transport.stop_listener(addr)?;
@@ -185,7 +185,7 @@ impl<T: HandshakeHandler> PeerNetManager<T> {
                     self.active_connections.clone(),
                     self.fallback_function,
                     self.config.message_handlers.clone(),
-                    self.config.optionnal_features.clone(),
+                    self.config.optional_features.clone(),
                 )
             });
         transport.try_connect(

--- a/src/network_manager.rs
+++ b/src/network_manager.rs
@@ -12,7 +12,7 @@ use crate::{
     config::PeerNetConfiguration,
     error::PeerNetResult,
     handlers::MessageHandlers,
-    peer::{HandshakeHandler, PeerConnection},
+    peer::{HandshakeHandler, PeerConnection, SendChannels},
     peer_id::PeerId,
     transports::{
         endpoint::Endpoint, InternalTransportType, OutConnectionConfig, Transport, TransportType,
@@ -27,6 +27,8 @@ pub struct ActiveConnections {
     pub max_in_connections: usize,
     /// Number of peers we want to have in OUT connection
     pub max_out_connections: usize,
+    /// Peers attempting to connect but not yet finished initialization
+    pub connection_queue: Vec<SocketAddr>,
     pub connections: HashMap<PeerId, PeerConnection>,
     pub listeners: HashMap<SocketAddr, TransportType>,
 }
@@ -34,14 +36,38 @@ pub struct ActiveConnections {
 impl ActiveConnections {
     /// Check if a new connection from a specific address can be accepted or not
     pub fn check_addr_accepted(&self, addr: &SocketAddr) -> bool {
-        if self.connections.is_empty() {
+        if self.connections.is_empty() && self.connection_queue.is_empty() {
             true
         } else {
-            !self
+            let active_connection_match = self
                 .connections
                 .iter()
-                .any(|(_, connection)| connection.endpoint.get_target_addr().ip() == addr.ip())
+                .any(|(_, connection)| connection.endpoint.get_target_addr().ip() == addr.ip());
+            let queue_connection_match = self
+                .connection_queue
+                .iter()
+                .any(|peer| peer.ip() == addr.ip());
+            !(queue_connection_match || active_connection_match)
         }
+    }
+
+    pub fn confirm_connection(
+        &mut self,
+        id: PeerId,
+        endpoint: Endpoint,
+        send_channels: SendChannels,
+    ) {
+        self.connection_queue
+            .retain(|addr| addr != endpoint.get_target_addr());
+        self.connections.insert(
+            id,
+            PeerConnection {
+                send_channels,
+                //TODO: Should be only the field that allow to shutdown the connection. As it's
+                //transport specific, it should be a wrapped type `ShutdownHandle`
+                endpoint,
+            },
+        );
     }
 }
 
@@ -81,6 +107,7 @@ impl<T: HandshakeHandler> PeerNetManager<T> {
             nb_out_connections: 0,
             max_in_connections: config.max_in_connections,
             max_out_connections: config.max_out_connections,
+            connection_queue: vec![],
             connections: Default::default(),
             listeners: Default::default(),
         }));
@@ -107,6 +134,7 @@ impl<T: HandshakeHandler> PeerNetManager<T> {
                 self.active_connections.clone(),
                 self.fallback_function,
                 self.config.message_handlers.clone(),
+                self.config.optionnal_features.clone(),
             )
         });
         transport.start_listener(
@@ -130,6 +158,7 @@ impl<T: HandshakeHandler> PeerNetManager<T> {
                 self.active_connections.clone(),
                 self.fallback_function,
                 self.config.message_handlers.clone(),
+                self.config.optionnal_features.clone(),
             )
         });
         transport.stop_listener(addr)?;
@@ -156,6 +185,7 @@ impl<T: HandshakeHandler> PeerNetManager<T> {
                     self.active_connections.clone(),
                     self.fallback_function,
                     self.config.message_handlers.clone(),
+                    self.config.optionnal_features.clone(),
                 )
             });
         transport.try_connect(

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -108,21 +108,15 @@ pub(crate) fn new_peer<T: HandshakeHandler>(
         let (low_write_tx, low_write_rx) = unbounded::<Vec<u8>>();
         let (high_write_tx, high_write_rx) = unbounded::<Vec<u8>>();
 
-        {
-            let mut active_connections = active_connections.write();
-            active_connections.connections.insert(
-                peer_id.clone(),
-                PeerConnection {
-                    //TODO: Should be only the field that allow to shutdown the connection. As it's
-                    //transport specific, it should be a wrapped type `ShutdownHandle`
-                    endpoint: endpoint.clone(),
-                    send_channels: SendChannels {
-                        low_priority: low_write_tx,
-                        high_priority: high_write_tx,
-                    },
-                },
-            );
-        }
+        active_connections.write().confirm_connection(
+            peer_id.clone(),
+            endpoint.clone(),
+            SendChannels {
+                low_priority: low_write_tx,
+                high_priority: high_write_tx,
+            },
+        );
+
         // SPAWN WRITING THREAD
         //TODO: Bound
         let mut write_endpoint = endpoint.clone();

--- a/src/transports/endpoint.rs
+++ b/src/transports/endpoint.rs
@@ -17,6 +17,13 @@ pub enum Endpoint {
 }
 
 impl Endpoint {
+    pub fn get_target_addr(&self) -> &std::net::SocketAddr {
+        match self {
+            Endpoint::Tcp(TcpEndpoint { address, .. }) => address,
+            Endpoint::Quic(QuicEndpoint { address, .. }) => address,
+        }
+    }
+
     pub fn send(&mut self, data: &[u8]) -> Result<(), PeerNetError> {
         match self {
             Endpoint::Tcp(endpoint) => TcpTransport::send(endpoint, data),

--- a/src/transports/mod.rs
+++ b/src/transports/mod.rs
@@ -10,6 +10,7 @@ use crate::{
     handlers::MessageHandlers,
     network_manager::{FallbackFunction, SharedActiveConnections},
     peer::HandshakeHandler,
+    config::PeerNetFeatures,
 };
 
 use self::{endpoint::Endpoint, quic::QuicTransport, tcp::TcpTransport};
@@ -148,17 +149,20 @@ impl InternalTransportType {
         active_connections: SharedActiveConnections,
         fallback_function: Option<&'static FallbackFunction>,
         message_handlers: MessageHandlers,
+        features: PeerNetFeatures,
     ) -> Self {
         match transport_type {
             TransportType::Tcp => InternalTransportType::Tcp(TcpTransport::new(
                 active_connections,
                 fallback_function,
                 message_handlers,
+                features,
             )),
             TransportType::Quic => InternalTransportType::Quic(QuicTransport::new(
                 active_connections,
                 fallback_function,
                 message_handlers,
+                features,
             )),
         }
     }

--- a/src/transports/mod.rs
+++ b/src/transports/mod.rs
@@ -6,11 +6,11 @@ use std::thread::JoinHandle;
 use std::{net::SocketAddr, time::Duration};
 
 use crate::{
+    config::PeerNetFeatures,
     error::{PeerNetError, PeerNetResult},
     handlers::MessageHandlers,
     network_manager::{FallbackFunction, SharedActiveConnections},
     peer::HandshakeHandler,
-    config::PeerNetFeatures,
 };
 
 use self::{endpoint::Endpoint, quic::QuicTransport, tcp::TcpTransport};

--- a/src/transports/quic.rs
+++ b/src/transports/quic.rs
@@ -12,13 +12,13 @@ use mio::{net::UdpSocket as MioUdpSocket, Events, Interest, Poll, Token, Waker};
 use parking_lot::RwLock;
 
 use crate::{
+    config::PeerNetFeatures,
     error::{PeerNetError, PeerNetResult},
     handlers::MessageHandlers,
     network_manager::{FallbackFunction, SharedActiveConnections},
     peer::{new_peer, HandshakeHandler},
     peer_id::PeerId,
     transports::{Endpoint, TransportErrorType},
-    config::PeerNetFeatures,
 };
 
 use super::Transport;
@@ -280,7 +280,7 @@ impl Transport for QuicTransport {
                                             Endpoint::Quic(QuicEndpoint {
                                                 data_receiver: recv_rx,
                                                 data_sender: send_tx,
-                                                address: address,
+                                                address,
                                             }),
                                             handshake_handler.clone(),
                                             message_handlers.clone(),
@@ -526,7 +526,7 @@ impl Transport for QuicTransport {
                     Endpoint::Quic(QuicEndpoint {
                         data_receiver: recv_rx,
                         data_sender: send_tx,
-                        address: address,
+                        address,
                     }),
                     handshake_handler.clone(),
                     message_handlers.clone(),

--- a/src/transports/quic.rs
+++ b/src/transports/quic.rs
@@ -56,6 +56,7 @@ pub(crate) enum QuicInternalMessage {
 pub struct QuicEndpoint {
     pub(crate) data_sender: channel::Sender<QuicInternalMessage>,
     pub(crate) data_receiver: channel::Receiver<QuicInternalMessage>,
+    pub address: SocketAddr,
 }
 
 impl QuicEndpoint {
@@ -224,6 +225,7 @@ impl Transport for QuicTransport {
                                             Endpoint::Quic(QuicEndpoint {
                                                 data_receiver: recv_rx,
                                                 data_sender: send_tx,
+                                                address: address,
                                             }),
                                             handshake_handler.clone(),
                                             message_handlers.clone(),
@@ -428,6 +430,7 @@ impl Transport for QuicTransport {
                     Endpoint::Quic(QuicEndpoint {
                         data_receiver: recv_rx,
                         data_sender: send_tx,
+                        address: address,
                     }),
                     handshake_handler.clone(),
                     message_handlers.clone(),

--- a/src/transports/tcp.rs
+++ b/src/transports/tcp.rs
@@ -4,12 +4,12 @@ use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::thread::JoinHandle;
 use std::time::Duration;
 
+use crate::config::PeerNetFeatures;
 use crate::error::{PeerNetError, PeerNetResult};
 use crate::handlers::MessageHandlers;
 use crate::network_manager::{FallbackFunction, SharedActiveConnections};
 use crate::peer::{new_peer, HandshakeHandler};
 use crate::transports::Endpoint;
-use crate::config::PeerNetFeatures;
 
 use super::{Transport, TransportErrorType};
 
@@ -150,12 +150,14 @@ impl Transport for TcpTransport {
                                         None,
                                     )
                                 })?;
-                                if reject_same_ip_addr && !active_connections.read().check_addr_accepted(&address) {
+                                if reject_same_ip_addr
+                                    && !active_connections.read().check_addr_accepted(&address)
+                                {
                                     println!("Address {:?} refused", address);
                                     continue;
                                 }
                                 println!("Address {:?}, accepted", address);
-                                
+
                                 let mut endpoint = Endpoint::Tcp(TcpEndpoint {
                                     address,
                                     stream: Limiter::new(

--- a/src/transports/tcp.rs
+++ b/src/transports/tcp.rs
@@ -111,6 +111,11 @@ impl Transport for TcpTransport {
                                 //TODO: Error handling
                                 //TODO: Use rate limiting
                                 let (stream, address) = server.accept().unwrap();
+                                if !active_connections.read().check_addr_accepted(&address) {
+                                    println!("Address {:?} refused", address);
+                                    continue;
+                                }
+                                println!("Address {:?}, accepted", address);
                                 let mut endpoint = Endpoint::Tcp(TcpEndpoint { address, stream });
                                 {
                                     let mut active_connections = active_connections.write();

--- a/tests/handlers.rs
+++ b/tests/handlers.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use peernet::types::KeyPair;
 use peernet::{
-    config::{PeerNetFeatures, PeerNetConfiguration},
+    config::{PeerNetConfiguration, PeerNetFeatures},
     handlers::MessageHandlers,
     network_manager::PeerNetManager,
     peer::HandshakeHandler,
@@ -36,7 +36,7 @@ fn two_peers_tcp_with_one_handler() {
     let config = PeerNetConfiguration {
         max_in_connections: 10,
         max_out_connections: 20,
-        self_keypair: keypair1.clone(),
+        self_keypair: keypair1,
         handshake_handler: EmptyHandshake {},
         fallback_function: None,
         message_handlers: message_handlers.clone(),
@@ -50,7 +50,7 @@ fn two_peers_tcp_with_one_handler() {
     let config = PeerNetConfiguration {
         max_in_connections: 10,
         max_out_connections: 20,
-        self_keypair: keypair2.clone(),
+        self_keypair: keypair2,
         handshake_handler: EmptyHandshake {},
         fallback_function: None,
         message_handlers,

--- a/tests/handlers.rs
+++ b/tests/handlers.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use peernet::types::KeyPair;
 use peernet::{
-    config::PeerNetConfiguration,
+    config::{PeerNetFeatures, PeerNetConfiguration},
     handlers::MessageHandlers,
     network_manager::PeerNetManager,
     peer::HandshakeHandler,
@@ -40,6 +40,7 @@ fn two_peers_tcp_with_one_handler() {
         handshake_handler: EmptyHandshake {},
         fallback_function: None,
         message_handlers: message_handlers.clone(),
+        optionnal_features: PeerNetFeatures::default().set_reject_same_ip_addr(false),
     };
     let mut manager = PeerNetManager::new(config);
     manager
@@ -53,6 +54,7 @@ fn two_peers_tcp_with_one_handler() {
         handshake_handler: EmptyHandshake {},
         fallback_function: None,
         message_handlers,
+        optionnal_features: PeerNetFeatures::default().set_reject_same_ip_addr(false),
     };
     let mut manager2 = PeerNetManager::new(config);
     manager2

--- a/tests/handlers.rs
+++ b/tests/handlers.rs
@@ -40,7 +40,7 @@ fn two_peers_tcp_with_one_handler() {
         handshake_handler: EmptyHandshake {},
         fallback_function: None,
         message_handlers: message_handlers.clone(),
-        optionnal_features: PeerNetFeatures::default().set_reject_same_ip_addr(false),
+        optional_features: PeerNetFeatures::default().set_reject_same_ip_addr(false),
     };
     let mut manager = PeerNetManager::new(config);
     manager
@@ -54,7 +54,7 @@ fn two_peers_tcp_with_one_handler() {
         handshake_handler: EmptyHandshake {},
         fallback_function: None,
         message_handlers,
-        optionnal_features: PeerNetFeatures::default().set_reject_same_ip_addr(false),
+        optional_features: PeerNetFeatures::default().set_reject_same_ip_addr(false),
     };
     let mut manager2 = PeerNetManager::new(config);
     manager2

--- a/tests/limits.rs
+++ b/tests/limits.rs
@@ -24,7 +24,7 @@ fn check_mutliple_connection_refused() {
         handshake_handler: DefaultHandshake {},
         fallback_function: None,
         message_handlers: Default::default(),
-        optionnal_features: PeerNetFeatures::default().set_reject_same_ip_addr(true),
+        optional_features: PeerNetFeatures::default().set_reject_same_ip_addr(true),
     };
     let mut manager = PeerNetManager::new(config);
     manager
@@ -39,14 +39,14 @@ fn check_mutliple_connection_refused() {
         fallback_function: None,
         message_handlers: Default::default(),
         handshake_handler: DefaultHandshake {},
-        optionnal_features: PeerNetFeatures::default().set_reject_same_ip_addr(true),
+        optional_features: PeerNetFeatures::default().set_reject_same_ip_addr(true),
     };
     let mut manager2 = PeerNetManager::new(config);
     manager2
         .try_connect(
             "127.0.0.1:8081".parse().unwrap(),
             Duration::from_secs(3),
-            &mut OutConnectionConfig::Tcp(TcpOutConnectionConfig {}),
+            &mut OutConnectionConfig::Tcp(Box::new(TcpOutConnectionConfig {})),
         )
         .unwrap();
     std::thread::sleep(std::time::Duration::from_secs(3));
@@ -58,14 +58,14 @@ fn check_mutliple_connection_refused() {
         fallback_function: None,
         message_handlers: Default::default(),
         handshake_handler: DefaultHandshake {},
-        optionnal_features: PeerNetFeatures::default().set_reject_same_ip_addr(true),
+        optional_features: PeerNetFeatures::default().set_reject_same_ip_addr(true),
     };
     let mut manager3 = PeerNetManager::new(config);
     manager3
         .try_connect(
             "127.0.0.1:8081".parse().unwrap(),
             Duration::from_secs(3),
-            &mut OutConnectionConfig::Tcp(TcpOutConnectionConfig {}),
+            &mut OutConnectionConfig::Tcp(Box::new(TcpOutConnectionConfig {})),
         )
         .unwrap();
     std::thread::sleep(std::time::Duration::from_secs(3));

--- a/tests/limits.rs
+++ b/tests/limits.rs
@@ -1,12 +1,10 @@
 // All the tests related to the limitations on the system.
 
 use peernet::{
-    config::{PeerNetFeatures, PeerNetConfiguration},
+    config::{PeerNetConfiguration, PeerNetFeatures},
     network_manager::PeerNetManager,
     peer::HandshakeHandler,
-    transports::{
-        OutConnectionConfig, TcpOutConnectionConfig, TransportType,
-    },
+    transports::{OutConnectionConfig, TcpOutConnectionConfig, TransportType},
 };
 use std::time::Duration;
 

--- a/tests/limits.rs
+++ b/tests/limits.rs
@@ -1,0 +1,81 @@
+// All the tests related to the limitations on the system.
+
+use peernet::{
+    config::{PeerNetFeatures, PeerNetConfiguration},
+    network_manager::PeerNetManager,
+    peer::HandshakeHandler,
+    transports::{
+        OutConnectionConfig, TcpOutConnectionConfig, TransportType,
+    },
+};
+use std::time::Duration;
+
+use peernet::types::KeyPair;
+
+#[derive(Clone)]
+pub struct DefaultHandshake;
+impl HandshakeHandler for DefaultHandshake {}
+
+#[test]
+fn check_mutliple_connection_refused() {
+    let keypair1 = KeyPair::generate();
+    let config = PeerNetConfiguration {
+        max_in_connections: 10,
+        max_out_connections: 20,
+        self_keypair: keypair1.clone(),
+        handshake_handler: DefaultHandshake {},
+        fallback_function: None,
+        message_handlers: Default::default(),
+        optionnal_features: PeerNetFeatures::default().set_reject_same_ip_addr(true),
+    };
+    let mut manager = PeerNetManager::new(config);
+    manager
+        .start_listener(TransportType::Tcp, "127.0.0.1:8081".parse().unwrap())
+        .unwrap();
+
+    let keypair2 = KeyPair::generate();
+    let config = PeerNetConfiguration {
+        max_in_connections: 10,
+        max_out_connections: 20,
+        self_keypair: keypair2.clone(),
+        fallback_function: None,
+        message_handlers: Default::default(),
+        handshake_handler: DefaultHandshake {},
+        optionnal_features: PeerNetFeatures::default().set_reject_same_ip_addr(true),
+    };
+    let mut manager2 = PeerNetManager::new(config);
+    manager2
+        .try_connect(
+            "127.0.0.1:8081".parse().unwrap(),
+            Duration::from_secs(3),
+            &mut OutConnectionConfig::Tcp(TcpOutConnectionConfig {}),
+        )
+        .unwrap();
+    std::thread::sleep(std::time::Duration::from_secs(3));
+
+    let config = PeerNetConfiguration {
+        max_in_connections: 10,
+        max_out_connections: 20,
+        self_keypair: keypair2.clone(),
+        fallback_function: None,
+        message_handlers: Default::default(),
+        handshake_handler: DefaultHandshake {},
+        optionnal_features: PeerNetFeatures::default().set_reject_same_ip_addr(true),
+    };
+    let mut manager3 = PeerNetManager::new(config);
+    manager3
+        .try_connect(
+            "127.0.0.1:8081".parse().unwrap(),
+            Duration::from_secs(3),
+            &mut OutConnectionConfig::Tcp(TcpOutConnectionConfig {}),
+        )
+        .unwrap();
+    std::thread::sleep(std::time::Duration::from_secs(3));
+
+    assert_eq!(manager.nb_in_connections(), 1);
+    manager
+        .stop_listener(TransportType::Tcp, "127.0.0.1:8081".parse().unwrap())
+        .unwrap();
+}
+
+// TODO Perform limit tests for QUIC also

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -27,7 +27,7 @@ fn simple() {
         fallback_function: None,
         message_handlers: Default::default(),
         handshake_handler: DefaultHandshake,
-        optionnal_features: PeerNetFeatures::default().set_reject_same_ip_addr(false),
+        optional_features: PeerNetFeatures::default().set_reject_same_ip_addr(false),
     };
     let mut manager = PeerNetManager::new(config);
     manager
@@ -59,7 +59,7 @@ fn two_peers_tcp() {
         handshake_handler: DefaultHandshake {},
         fallback_function: None,
         message_handlers: Default::default(),
-        optionnal_features: PeerNetFeatures::default().set_reject_same_ip_addr(false),
+        optional_features: PeerNetFeatures::default().set_reject_same_ip_addr(false),
     };
     let mut manager = PeerNetManager::new(config);
     manager
@@ -74,7 +74,7 @@ fn two_peers_tcp() {
         fallback_function: None,
         message_handlers: Default::default(),
         handshake_handler: DefaultHandshake {},
-        optionnal_features: PeerNetFeatures::default().set_reject_same_ip_addr(false),
+        optional_features: PeerNetFeatures::default().set_reject_same_ip_addr(false),
     };
     let mut manager2 = PeerNetManager::new(config);
     sleep(Duration::from_secs(3));
@@ -102,7 +102,7 @@ fn two_peers_quic() {
         fallback_function: None,
         message_handlers: Default::default(),
         handshake_handler: DefaultHandshake {},
-        optionnal_features: PeerNetFeatures::default().set_reject_same_ip_addr(false),
+        optional_features: PeerNetFeatures::default().set_reject_same_ip_addr(false),
     };
     let mut manager = PeerNetManager::new(config);
     manager
@@ -117,7 +117,7 @@ fn two_peers_quic() {
         fallback_function: None,
         message_handlers: Default::default(),
         handshake_handler: DefaultHandshake {},
-        optionnal_features: PeerNetFeatures::default().set_reject_same_ip_addr(false),
+        optional_features: PeerNetFeatures::default().set_reject_same_ip_addr(false),
     };
     let mut manager2 = PeerNetManager::new(config);
     sleep(Duration::from_secs(3));

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -23,7 +23,7 @@ fn simple() {
     let config = PeerNetConfiguration {
         max_in_connections: 10,
         max_out_connections: 20,
-        self_keypair: keypair.clone(),
+        self_keypair: keypair,
         fallback_function: None,
         message_handlers: Default::default(),
         handshake_handler: DefaultHandshake,
@@ -55,7 +55,7 @@ fn two_peers_tcp() {
     let config = PeerNetConfiguration {
         max_in_connections: 10,
         max_out_connections: 20,
-        self_keypair: keypair1.clone(),
+        self_keypair: keypair1,
         handshake_handler: DefaultHandshake {},
         fallback_function: None,
         message_handlers: Default::default(),
@@ -70,7 +70,7 @@ fn two_peers_tcp() {
     let config = PeerNetConfiguration {
         max_in_connections: 10,
         max_out_connections: 20,
-        self_keypair: keypair2.clone(),
+        self_keypair: keypair2,
         fallback_function: None,
         message_handlers: Default::default(),
         handshake_handler: DefaultHandshake {},
@@ -82,7 +82,7 @@ fn two_peers_tcp() {
         .try_connect(
             "127.0.0.1:8081".parse().unwrap(),
             Duration::from_secs(3),
-            &mut OutConnectionConfig::Tcp(Box::new(TcpOutConnectionConfig {})),
+            &OutConnectionConfig::Tcp(Box::new(TcpOutConnectionConfig {})),
         )
         .unwrap();
     std::thread::sleep(std::time::Duration::from_secs(3));
@@ -113,7 +113,7 @@ fn two_peers_quic() {
     let config = PeerNetConfiguration {
         max_in_connections: 10,
         max_out_connections: 20,
-        self_keypair: keypair2.clone(),
+        self_keypair: keypair2,
         fallback_function: None,
         message_handlers: Default::default(),
         handshake_handler: DefaultHandshake {},

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -3,7 +3,7 @@ use std::{thread::sleep, time::Duration};
 
 use peernet::types::KeyPair;
 use peernet::{
-    config::PeerNetConfiguration,
+    config::{PeerNetConfiguration, PeerNetFeatures},
     network_manager::PeerNetManager,
     peer::HandshakeHandler,
     peer_id::PeerId,
@@ -27,6 +27,7 @@ fn simple() {
         fallback_function: None,
         message_handlers: Default::default(),
         handshake_handler: DefaultHandshake,
+        optionnal_features: PeerNetFeatures::default().set_reject_same_ip_addr(false),
     };
     let mut manager = PeerNetManager::new(config);
     manager
@@ -58,6 +59,7 @@ fn two_peers_tcp() {
         handshake_handler: DefaultHandshake {},
         fallback_function: None,
         message_handlers: Default::default(),
+        optionnal_features: PeerNetFeatures::default().set_reject_same_ip_addr(false),
     };
     let mut manager = PeerNetManager::new(config);
     manager
@@ -72,6 +74,7 @@ fn two_peers_tcp() {
         fallback_function: None,
         message_handlers: Default::default(),
         handshake_handler: DefaultHandshake {},
+        optionnal_features: PeerNetFeatures::default().set_reject_same_ip_addr(false),
     };
     let mut manager2 = PeerNetManager::new(config);
     sleep(Duration::from_secs(3));
@@ -99,6 +102,7 @@ fn two_peers_quic() {
         fallback_function: None,
         message_handlers: Default::default(),
         handshake_handler: DefaultHandshake {},
+        optionnal_features: PeerNetFeatures::default().set_reject_same_ip_addr(false),
     };
     let mut manager = PeerNetManager::new(config);
     manager
@@ -113,6 +117,7 @@ fn two_peers_quic() {
         fallback_function: None,
         message_handlers: Default::default(),
         handshake_handler: DefaultHandshake {},
+        optionnal_features: PeerNetFeatures::default().set_reject_same_ip_addr(false),
     };
     let mut manager2 = PeerNetManager::new(config);
     sleep(Duration::from_secs(3));


### PR DESCRIPTION
Closes #7 

Adds a function `check_addr_accepted` function in `ActiveConnections` that iter through all the established connection's addresses and check if the IP is the same or not. If it's the same, we the function returns `false` and we refuse the connection.

For some reasons it broke the `simple` test for me so I'll have to investigate this further before marking this as ready.