### PR TITLE
Remove hack to make stream_limiter work

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -754,9 +754,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "stream_limiter"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2182c38ed520c8c7b2fcbadef2ef7c74bcc2767b09a4f1edc8f021400e40cca"
+checksum = "c8c15323225cebaeebbf71fd83443d0cc7a7638a8d60b5f9f4108da65f755956"
 
 [[package]]
 name = "subtle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ massa_hash = { git = "https://github.com/massalabs/massa", package = "massa_hash
 massa_serialization = { git = "https://github.com/massalabs/massa", package = "massa_serialization" }
 massa_signature = { git = "https://github.com/massalabs/massa", package = "massa_signature" }
 serde = { version = "1.0", features = ["derive"] }
-stream_limiter = "1.1.0"
+stream_limiter = "1.2.0"
 thiserror = "1.0.39"
 
 [dev-dependencies]

--- a/src/transports/tcp.rs
+++ b/src/transports/tcp.rs
@@ -304,7 +304,6 @@ impl Transport for TcpTransport {
     fn send(endpoint: &mut Self::Endpoint, data: &[u8]) -> PeerNetResult<()> {
         endpoint
             .stream
-            .stream
             .write(&data.len().to_le_bytes())
             .map_err(|err| {
                 TcpError::ConnectionError.wrap().new(
@@ -313,7 +312,7 @@ impl Transport for TcpTransport {
                     Some(format!("{:?}", data.len().to_le_bytes())),
                 )
             })?;
-        endpoint.stream.stream.write(data).map_err(|err| {
+        endpoint.stream.write(data).map_err(|err| {
             TcpError::ConnectionError
                 .wrap()
                 .new("send data write", err, None)
@@ -325,13 +324,11 @@ impl Transport for TcpTransport {
         let mut len_bytes = [0u8; 8];
         endpoint
             .stream
-            .stream
             .read(&mut len_bytes)
             .map_err(|err| TcpError::ConnectionError.wrap().new("recv len", err, None))?;
         let len = usize::from_le_bytes(len_bytes);
         let mut data = vec![0u8; len];
         endpoint
-            .stream
             .stream
             .read(&mut data)
             .map_err(|err| TcpError::ConnectionError.wrap().new("recv data", err, None))?;


### PR DESCRIPTION
Closes #27 
Remove the need for a hack to make `stream_limiter` work.

Updates it to version `1.2.0` to benefit from the update