### PR TITLE
Add fallback_function to InitConnectionHandler trait with handshake

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -4,11 +4,11 @@
 //! It regroups all the information needed to initialize a PeerNet manager.
 
 use crate::messages::MessagesHandler;
+use crate::peer::InitConnectionHandler;
 use crate::types::KeyPair;
-use crate::{network_manager::FallbackFunction, peer::HandshakeHandler};
 
 /// Struct containing the configuration for the PeerNet manager.
-pub struct PeerNetConfiguration<T: HandshakeHandler, M: MessagesHandler> {
+pub struct PeerNetConfiguration<T: InitConnectionHandler, M: MessagesHandler> {
     /// Number of peers we want to have in IN connection
     pub max_in_connections: usize,
     /// Number of peers we want to have in OUT connection
@@ -17,23 +17,20 @@ pub struct PeerNetConfiguration<T: HandshakeHandler, M: MessagesHandler> {
     pub self_keypair: KeyPair,
     /// Optional function to trigger at handshake
     /// (local keypair, endpoint to the peer, remote peer_id, active_connections)
-    pub handshake_handler: T,
-    /// Optional function to trigger when we receive a connection from a peer and we don't accept it
-    pub fallback_function: Option<&'static FallbackFunction>,
+    pub init_connection_handler: T,
     /// Optional features to enable for the manager
     pub optional_features: PeerNetFeatures,
     /// Structure for message handler
     pub message_handler: M,
 }
 
-impl<T: HandshakeHandler, M: MessagesHandler> PeerNetConfiguration<T, M> {
-    pub fn default(handshake_handler: T, message_handler: M) -> Self {
+impl<T: InitConnectionHandler, M: MessagesHandler> PeerNetConfiguration<T, M> {
+    pub fn default(init_connection_handler: T, message_handler: M) -> Self {
         PeerNetConfiguration {
             max_in_connections: 0,
             max_out_connections: 0,
             self_keypair: KeyPair::generate(),
-            fallback_function: None,
-            handshake_handler,
+            init_connection_handler,
             optional_features: PeerNetFeatures::default(),
             message_handler,
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,14 +11,14 @@
 //!    error::PeerNetResult,
 //!    messages::MessagesHandler,
 //!    transports::{OutConnectionConfig, TcpOutConnectionConfig, QuicOutConnectionConfig, TransportType},
-//!    peer::HandshakeHandler,
+//!    peer::InitConnectionHandler,
 //!};
 //!
 //! // Declare a handshake handler to use
 //! #[derive(Clone)]
 //! pub struct DefaultHandshake;
 //! // Use the default implementation of the handshake
-//! impl HandshakeHandler for DefaultHandshake {}
+//! impl InitConnectionHandler for DefaultHandshake {}
 //! #[derive(Clone)]
 //! pub struct MessageHandler;
 //! impl MessagesHandler for MessageHandler {
@@ -40,8 +40,7 @@
 //!     max_out_connections: 20,
 //!     self_keypair: keypair1.clone(),
 //!     message_handler: MessageHandler {},
-//!     fallback_function: None,
-//!     handshake_handler: DefaultHandshake,
+//!     init_connection_handler: DefaultHandshake,
 //!     optional_features: PeerNetFeatures::default(),
 //! };
 //! // Setup the manager for the first peer
@@ -60,8 +59,7 @@
 //!     max_out_connections: 20,
 //!     self_keypair: keypair1.clone(),
 //!     message_handler: MessageHandler {},
-//!     fallback_function: None,
-//!     handshake_handler: DefaultHandshake,
+//!     init_connection_handler: DefaultHandshake,
 //!     optional_features: PeerNetFeatures::default(),
 //! };
 //! // Setup the manager for the second peer

--- a/src/network_manager.rs
+++ b/src/network_manager.rs
@@ -71,7 +71,6 @@ impl ActiveConnections {
     }
 }
 
-// Send some data to a peer that we didn't accept his connection
 pub type SharedActiveConnections = Arc<RwLock<ActiveConnections>>;
 
 /// Main structure of the PeerNet library used to manage the transports and the peers.

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -17,7 +17,7 @@ use crate::{
     transports::{endpoint::Endpoint, TransportType},
 };
 
-pub trait HandshakeHandler: Send + Clone + 'static {
+pub trait InitConnectionHandler: Send + Clone + 'static {
     fn perform_handshake<M: MessagesHandler>(
         &mut self,
         keypair: &KeyPair,
@@ -26,6 +26,15 @@ pub trait HandshakeHandler: Send + Clone + 'static {
         _messages_handler: M,
     ) -> PeerNetResult<PeerId> {
         endpoint.handshake(keypair)
+    }
+
+    fn fallback_function(
+        &mut self,
+        _keypair: &KeyPair,
+        _endpoint: &mut Endpoint,
+        _listeners: &HashMap<SocketAddr, TransportType>,
+    ) -> PeerNetResult<()> {
+        Ok(())
     }
 }
 
@@ -87,7 +96,7 @@ pub enum ConnectionType {
     OUT,
 }
 
-pub(crate) fn new_peer<T: HandshakeHandler, M: MessagesHandler>(
+pub(crate) fn new_peer<T: InitConnectionHandler, M: MessagesHandler>(
     self_keypair: KeyPair,
     mut endpoint: Endpoint,
     mut handshake_handler: T,

--- a/tests/limits.rs
+++ b/tests/limits.rs
@@ -3,7 +3,7 @@ mod util;
 use peernet::{
     config::{PeerNetConfiguration, PeerNetFeatures},
     network_manager::PeerNetManager,
-    peer::HandshakeHandler,
+    peer::InitConnectionHandler,
     transports::{OutConnectionConfig, TcpOutConnectionConfig, TransportType},
 };
 use std::time::Duration;
@@ -13,8 +13,8 @@ use peernet::types::KeyPair;
 use util::DefaultMessagesHandler;
 
 #[derive(Clone)]
-pub struct DefaultHandshake;
-impl HandshakeHandler for DefaultHandshake {}
+pub struct DefaultInitConnection;
+impl InitConnectionHandler for DefaultInitConnection {}
 
 #[test]
 fn check_mutliple_connection_refused() {
@@ -22,9 +22,8 @@ fn check_mutliple_connection_refused() {
     let config = PeerNetConfiguration {
         max_in_connections: 10,
         max_out_connections: 20,
-        self_keypair: keypair1.clone(),
-        handshake_handler: DefaultHandshake {},
-        fallback_function: None,
+        self_keypair: keypair1,
+        init_connection_handler: DefaultInitConnection {},
         optional_features: PeerNetFeatures::default().set_reject_same_ip_addr(true),
         message_handler: DefaultMessagesHandler {},
     };
@@ -38,8 +37,7 @@ fn check_mutliple_connection_refused() {
         max_in_connections: 10,
         max_out_connections: 20,
         self_keypair: keypair2.clone(),
-        fallback_function: None,
-        handshake_handler: DefaultHandshake {},
+        init_connection_handler: DefaultInitConnection {},
         optional_features: PeerNetFeatures::default().set_reject_same_ip_addr(true),
         message_handler: DefaultMessagesHandler {},
     };
@@ -56,9 +54,8 @@ fn check_mutliple_connection_refused() {
     let config = PeerNetConfiguration {
         max_in_connections: 10,
         max_out_connections: 20,
-        self_keypair: keypair2.clone(),
-        fallback_function: None,
-        handshake_handler: DefaultHandshake {},
+        self_keypair: keypair2,
+        init_connection_handler: DefaultInitConnection {},
         optional_features: PeerNetFeatures::default().set_reject_same_ip_addr(true),
         message_handler: DefaultMessagesHandler {},
     };

--- a/tests/messages.rs
+++ b/tests/messages.rs
@@ -7,14 +7,14 @@ use peernet::types::KeyPair;
 use peernet::{
     config::{PeerNetConfiguration, PeerNetFeatures},
     network_manager::PeerNetManager,
-    peer::HandshakeHandler,
+    peer::InitConnectionHandler,
     peer_id::PeerId,
     transports::{OutConnectionConfig, TcpOutConnectionConfig, TransportType},
 };
 
 #[derive(Clone)]
-struct EmptyHandshake;
-impl HandshakeHandler for EmptyHandshake {}
+struct EmptyInitConnection;
+impl InitConnectionHandler for EmptyInitConnection {}
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 enum TestMessages {
@@ -84,8 +84,7 @@ fn two_peers_tcp_with_one_message() {
         max_in_connections: 10,
         max_out_connections: 20,
         self_keypair: keypair1,
-        handshake_handler: EmptyHandshake {},
-        fallback_function: None,
+        init_connection_handler: EmptyInitConnection {},
         message_handler: TestMessagesHandler {
             test_sender: sender.clone(),
         },
@@ -100,8 +99,7 @@ fn two_peers_tcp_with_one_message() {
         max_in_connections: 10,
         max_out_connections: 20,
         self_keypair: keypair2,
-        handshake_handler: EmptyHandshake {},
-        fallback_function: None,
+        init_connection_handler: EmptyInitConnection {},
         message_handler: TestMessagesHandler {
             test_sender: sender,
         },

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -5,7 +5,7 @@ use peernet::types::KeyPair;
 use peernet::{
     config::{PeerNetConfiguration, PeerNetFeatures},
     network_manager::PeerNetManager,
-    peer::HandshakeHandler,
+    peer::InitConnectionHandler,
     peer_id::PeerId,
     transports::{
         OutConnectionConfig, QuicOutConnectionConfig, TcpOutConnectionConfig, TransportType,
@@ -14,8 +14,8 @@ use peernet::{
 use util::{create_clients, DefaultMessagesHandler};
 
 #[derive(Clone)]
-pub struct DefaultHandshake;
-impl HandshakeHandler for DefaultHandshake {
+pub struct DefaultInitConnection;
+impl InitConnectionHandler for DefaultInitConnection {
     fn perform_handshake<M: peernet::messages::MessagesHandler>(
         &mut self,
         _keypair: &KeyPair,
@@ -35,8 +35,7 @@ fn simple() {
         max_in_connections: 10,
         max_out_connections: 20,
         self_keypair: keypair,
-        fallback_function: None,
-        handshake_handler: DefaultHandshake,
+        init_connection_handler: DefaultInitConnection,
         optional_features: PeerNetFeatures::default().set_reject_same_ip_addr(false),
         message_handler: DefaultMessagesHandler {},
     };
@@ -64,8 +63,7 @@ fn two_peers_tcp() {
         max_in_connections: 10,
         max_out_connections: 20,
         self_keypair: keypair1,
-        handshake_handler: DefaultHandshake {},
-        fallback_function: None,
+        init_connection_handler: DefaultInitConnection {},
         optional_features: PeerNetFeatures::default().set_reject_same_ip_addr(false),
         message_handler: DefaultMessagesHandler {},
     };
@@ -79,8 +77,7 @@ fn two_peers_tcp() {
         max_in_connections: 10,
         max_out_connections: 20,
         self_keypair: keypair2,
-        fallback_function: None,
-        handshake_handler: DefaultHandshake {},
+        init_connection_handler: DefaultInitConnection {},
         optional_features: PeerNetFeatures::default().set_reject_same_ip_addr(false),
         message_handler: DefaultMessagesHandler {},
     };
@@ -107,8 +104,7 @@ fn two_peers_quic() {
         max_in_connections: 10,
         max_out_connections: 20,
         self_keypair: keypair1.clone(),
-        fallback_function: None,
-        handshake_handler: DefaultHandshake {},
+        init_connection_handler: DefaultInitConnection {},
         message_handler: DefaultMessagesHandler {},
         optional_features: PeerNetFeatures::default().set_reject_same_ip_addr(false),
     };
@@ -122,8 +118,7 @@ fn two_peers_quic() {
         max_in_connections: 10,
         max_out_connections: 20,
         self_keypair: keypair2,
-        fallback_function: None,
-        handshake_handler: DefaultHandshake {},
+        init_connection_handler: DefaultInitConnection {},
         optional_features: PeerNetFeatures::default().set_reject_same_ip_addr(false),
         message_handler: DefaultMessagesHandler {},
     };


### PR DESCRIPTION
Rename the `HandshakeHandler` to `InitConnectionHandler`, and adds `fallback_function` to it.