### PR TITLE
Use named threads to improve debugging

### DIFF
--- a/src/peer.rs
+++ b/src/peer.rs
@@ -106,7 +106,9 @@ pub(crate) fn new_peer<T: InitConnectionHandler, M: MessagesHandler>(
     connection_type: ConnectionType,
 ) {
     //TODO: All the unwrap should pass the error to a function that remove the peer from our records
-    std::thread::spawn(move || {
+    std::thread::Builder::new()
+        .name("peer_thread".into())
+        .spawn(move || {
         let listeners = {
             let active_connections = active_connections.read();
             active_connections.listeners.clone()
@@ -335,5 +337,5 @@ pub(crate) fn new_peer<T: InitConnectionHandler, M: MessagesHandler>(
                 }
             }
         }
-    });
+    }).expect("Failed to spawn peer_thread");
 }

--- a/src/transports/tcp.rs
+++ b/src/transports/tcp.rs
@@ -239,49 +239,50 @@ impl Transport for TcpTransport {
         Ok(std::thread::Builder::new()
             .name(format!("tcp_try_connect_{:?}", address))
             .spawn({
-            let active_connections = self.active_connections.clone();
-            let wg = self.out_connection_attempts.clone();
-            move || {
-                let stream = TcpStream::connect_timeout(&address, timeout).map_err(|err| {
-                    TcpError::ConnectionError.wrap().new(
-                        "try_connect stream connect",
-                        err,
-                        Some(format!("address: {}, timeout: {:?}", address, timeout)),
-                    )
-                })?;
-                let stream = Limiter::new(stream, RATE_LIMIT, Duration::from_secs(1));
-                println!("Connected to {}", address);
+                let active_connections = self.active_connections.clone();
+                let wg = self.out_connection_attempts.clone();
+                move || {
+                    let stream = TcpStream::connect_timeout(&address, timeout).map_err(|err| {
+                        TcpError::ConnectionError.wrap().new(
+                            "try_connect stream connect",
+                            err,
+                            Some(format!("address: {}, timeout: {:?}", address, timeout)),
+                        )
+                    })?;
+                    let stream = Limiter::new(stream, RATE_LIMIT, Duration::from_secs(1));
+                    println!("Connected to {}", address);
 
-                {
-                    let mut active_connections = active_connections.write();
-                    if active_connections.nb_out_connections
-                        < active_connections.max_out_connections
                     {
-                        active_connections.nb_out_connections += 1;
-                    } else {
-                        return Err(PeerNetError::BoundReached.error(
-                            "tcp try_connect max_out_conn",
-                            Some(format!(
-                                "max: {}, nb: {}",
-                                active_connections.max_out_connections,
-                                active_connections.nb_out_connections
-                            )),
-                        ))?;
+                        let mut active_connections = active_connections.write();
+                        if active_connections.nb_out_connections
+                            < active_connections.max_out_connections
+                        {
+                            active_connections.nb_out_connections += 1;
+                        } else {
+                            return Err(PeerNetError::BoundReached.error(
+                                "tcp try_connect max_out_conn",
+                                Some(format!(
+                                    "max: {}, nb: {}",
+                                    active_connections.max_out_connections,
+                                    active_connections.nb_out_connections
+                                )),
+                            ))?;
+                        }
                     }
+                    new_peer(
+                        self_keypair.clone(),
+                        Endpoint::Tcp(TcpEndpoint { address, stream }),
+                        handshake_handler.clone(),
+                        message_handler.clone(),
+                        active_connections.clone(),
+                        peer_stop_rx,
+                        ConnectionType::OUT,
+                    );
+                    drop(wg);
+                    Ok(())
                 }
-                new_peer(
-                    self_keypair.clone(),
-                    Endpoint::Tcp(TcpEndpoint { address, stream }),
-                    handshake_handler.clone(),
-                    message_handler.clone(),
-                    active_connections.clone(),
-                    peer_stop_rx,
-                    ConnectionType::OUT,
-                );
-                drop(wg);
-                Ok(())
-            }
-        }).expect("Failed to spawn thread tcp_try_connect"))
+            })
+            .expect("Failed to spawn thread tcp_try_connect"))
     }
 
     fn stop_listener(&mut self, address: SocketAddr) -> PeerNetResult<()> {

--- a/src/transports/tcp.rs
+++ b/src/transports/tcp.rs
@@ -123,7 +123,9 @@ impl Transport for TcpTransport {
         let mut events = Events::with_capacity(128);
         let waker = Waker::new(poll.registry(), STOP_LISTENER)
             .map_err(|err| TcpError::InitListener.wrap().new("waker new", err, None))?;
-        let listener_handle: JoinHandle<PeerNetResult<()>> = std::thread::spawn({
+        let listener_handle: JoinHandle<PeerNetResult<()>> = std::thread::Builder::new()
+            .name(format!("tcp_listener_handle_{:?}", address))
+            .spawn({
             let active_connections = self.active_connections.clone();
             let reject_same_ip_addr = self.features.reject_same_ip_addr;
             let peer_stop_rx = self.peer_stop_rx.clone();
@@ -213,7 +215,7 @@ impl Transport for TcpTransport {
                     }
                 }
             }
-        });
+        }).expect("Failed to spawn thread tcp_listener_handle");
         {
             let mut active_connections = self.active_connections.write();
             active_connections
@@ -234,7 +236,9 @@ impl Transport for TcpTransport {
         handshake_handler: T,
     ) -> PeerNetResult<JoinHandle<PeerNetResult<()>>> {
         let peer_stop_rx = self.peer_stop_rx.clone();
-        Ok(std::thread::spawn({
+        Ok(std::thread::Builder::new()
+            .name(format!("tcp_try_connect_{:?}", address))
+            .spawn({
             let active_connections = self.active_connections.clone();
             let wg = self.out_connection_attempts.clone();
             move || {
@@ -277,7 +281,7 @@ impl Transport for TcpTransport {
                 drop(wg);
                 Ok(())
             }
-        }))
+        }).expect("Failed to spawn thread tcp_try_connect"))
     }
 
     fn stop_listener(&mut self, address: SocketAddr) -> PeerNetResult<()> {

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -25,12 +25,14 @@ impl MessagesHandler for DefaultMessagesHandler {
 
 pub fn create_clients(nb_clients: usize) -> Vec<JoinHandle<()>> {
     let mut clients = Vec::new();
-    for _ in 0..nb_clients {
-        let client = std::thread::spawn(|| {
+    for ncli in 0..nb_clients {
+        let client = std::thread::Builder::new()
+            .name(format!("test_client_{}", ncli))
+            .spawn(|| {
             let stream = std::net::TcpStream::connect("127.0.0.1:64850").unwrap();
             sleep(Duration::from_secs(100));
             stream.shutdown(std::net::Shutdown::Both).unwrap();
-        });
+        }).expect("Failed to spawn thread test_client");
         sleep(Duration::from_millis(100));
         clients.push(client);
     }

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -29,10 +29,11 @@ pub fn create_clients(nb_clients: usize) -> Vec<JoinHandle<()>> {
         let client = std::thread::Builder::new()
             .name(format!("test_client_{}", ncli))
             .spawn(|| {
-            let stream = std::net::TcpStream::connect("127.0.0.1:64850").unwrap();
-            sleep(Duration::from_secs(100));
-            stream.shutdown(std::net::Shutdown::Both).unwrap();
-        }).expect("Failed to spawn thread test_client");
+                let stream = std::net::TcpStream::connect("127.0.0.1:64850").unwrap();
+                sleep(Duration::from_secs(100));
+                stream.shutdown(std::net::Shutdown::Both).unwrap();
+            })
+            .expect("Failed to spawn thread test_client");
         sleep(Duration::from_millis(100));
         clients.push(client);
     }


### PR DESCRIPTION
Closes #34 

Use `std::thread::Builder` to spawn threads using specific names to improve debugging