### PR TITLE
Remove limiter

### DIFF
--- a/src/transports/tcp.rs
+++ b/src/transports/tcp.rs
@@ -19,7 +19,7 @@ use crossbeam::channel::{unbounded, Receiver, Sender};
 use crossbeam::sync::WaitGroup;
 use mio::net::TcpListener as MioTcpListener;
 use mio::{Events, Interest, Poll, Token, Waker};
-use stream_limiter::{Limiter, LimiterOptions};
+use stream_limiter::LimiterOptions;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum TcpError {

--- a/tests/limits.rs
+++ b/tests/limits.rs
@@ -13,7 +13,6 @@ use std::{
     str::FromStr,
     time::Duration,
 };
-use stream_limiter::Limiter;
 
 // use peernet::types::KeyPair;
 
@@ -450,7 +449,7 @@ fn max_message_size() {
         }
         .into(),
         address: "127.0.0.1:18084".parse().unwrap(),
-        stream: Limiter::new(stream, None, None),
+        stream
     });
 
     std::thread::sleep(std::time::Duration::from_secs(1));
@@ -532,7 +531,7 @@ fn send_timeout() {
         }
         .into(),
         address: "127.0.0.1:18085".parse().unwrap(),
-        stream: Limiter::new(stream, None, None),
+        stream
     });
 
     std::thread::sleep(std::time::Duration::from_secs(1));

--- a/tests/limits.rs
+++ b/tests/limits.rs
@@ -449,7 +449,7 @@ fn max_message_size() {
         }
         .into(),
         address: "127.0.0.1:18084".parse().unwrap(),
-        stream
+        stream,
     });
 
     std::thread::sleep(std::time::Duration::from_secs(1));
@@ -531,7 +531,7 @@ fn send_timeout() {
         }
         .into(),
         address: "127.0.0.1:18085".parse().unwrap(),
-        stream
+        stream,
     });
 
     std::thread::sleep(std::time::Duration::from_secs(1));


### PR DESCRIPTION
Limiter seems to broke the network for now regarding tests that I have made on the latest version on massa. Looking at the deadline we have for massa for the next version, let's not include it in the next version.