### PR TITLE
Get random available TCP port instead of hardcoded ones

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,9 +92,21 @@
 //! DefaultInitConnection,
 //! DefaultMessagesHandler,
 //! > = PeerNetManager::new(config);
-//! // Setup the listener for the TCP transport to 8081 port.
+//! // Get a random TCP port to connect to
+//! let port = {
+//!    let mut port = 0;
+//!    for test_port in 10000..u16::MAX {
+//!        if std::net::TcpListener::bind(("127.0.0.1", test_port)).is_ok() {
+//!            port = test_port;
+//!            break;
+//!         }
+//!     }
+//!    assert_ne!(port, 0, "No TCP ports available");
+//!    port
+//! };
+//! // Setup the listener for the TCP transport to the port.
 //! manager
-//!     .start_listener(TransportType::Tcp, "127.0.0.1:8081".parse().unwrap())
+//!     .start_listener(TransportType::Tcp, format!("127.0.0.1:{port}").parse().unwrap())
 //!     .unwrap();
 //!
 
@@ -129,18 +141,18 @@
 //! DefaultInitConnection,
 //! DefaultMessagesHandler,
 //! > = PeerNetManager::new(config);
-//! // Try to connect to the first peer listener on TCP port 8081.
+//! // Try to connect to the first peer listener on its TCP port.
 //! manager2
 //!     .try_connect(
 //!         TransportType::Tcp,
-//!         "127.0.0.1:8081".parse().unwrap(),
+//!         format!("127.0.0.1:{port}").parse().unwrap(),
 //!         Duration::from_secs(3),
 //!     )
 //!     .unwrap();
 //! std::thread::sleep(std::time::Duration::from_secs(3));
 //! // Close the listener of the first peer
 //! manager
-//!     .stop_listener(TransportType::Tcp, "127.0.0.1:8081".parse().unwrap())
+//!     .stop_listener(TransportType::Tcp, format!("127.0.0.1:{port}").parse().unwrap())
 //!    .unwrap();
 //! ```
 

--- a/tests/limits.rs
+++ b/tests/limits.rs
@@ -73,7 +73,10 @@ fn check_multiple_connection_refused() {
 
     let port = get_tcp_port(10000..u16::MAX);
     manager
-        .start_listener(TransportType::Tcp, format!("127.0.0.1:{port}").parse().unwrap())
+        .start_listener(
+            TransportType::Tcp,
+            format!("127.0.0.1:{port}").parse().unwrap(),
+        )
         .unwrap();
 
     let context2 = DefaultContext {
@@ -153,7 +156,10 @@ fn check_multiple_connection_refused() {
 
     assert_eq!(manager.nb_in_connections(), 1);
     manager
-        .stop_listener(TransportType::Tcp, format!("127.0.0.1:{port}").parse().unwrap())
+        .stop_listener(
+            TransportType::Tcp,
+            format!("127.0.0.1:{port}").parse().unwrap(),
+        )
         .unwrap();
 }
 
@@ -190,7 +196,10 @@ fn check_too_much_in_refuse() {
 
     let port = get_tcp_port(10000..u16::MAX);
     manager
-        .start_listener(TransportType::Tcp, format!("127.0.0.1:{port}").parse().unwrap())
+        .start_listener(
+            TransportType::Tcp,
+            format!("127.0.0.1:{port}").parse().unwrap(),
+        )
         .unwrap();
 
     let context2 = DefaultContext {
@@ -271,7 +280,10 @@ fn check_too_much_in_refuse() {
 
     assert_eq!(manager.nb_in_connections(), 1);
     manager
-        .stop_listener(TransportType::Tcp, format!("127.0.0.1:{port}").parse().unwrap())
+        .stop_listener(
+            TransportType::Tcp,
+            format!("127.0.0.1:{port}").parse().unwrap(),
+        )
         .unwrap();
 }
 
@@ -320,7 +332,10 @@ fn check_multiple_connection_refused_in_category() {
     > = PeerNetManager::new(config);
     let port = get_tcp_port(10000..u16::MAX);
     manager
-        .start_listener(TransportType::Tcp, format!("127.0.0.1:{port}").parse().unwrap())
+        .start_listener(
+            TransportType::Tcp,
+            format!("127.0.0.1:{port}").parse().unwrap(),
+        )
         .unwrap();
 
     let context2 = DefaultContext {
@@ -401,7 +416,10 @@ fn check_multiple_connection_refused_in_category() {
 
     assert_eq!(manager.nb_in_connections(), 1);
     manager
-        .stop_listener(TransportType::Tcp, format!("127.0.0.1:{port}").parse().unwrap())
+        .stop_listener(
+            TransportType::Tcp,
+            format!("127.0.0.1:{port}").parse().unwrap(),
+        )
         .unwrap();
 }
 
@@ -440,7 +458,10 @@ fn max_message_size() {
 
     let port = get_tcp_port(10000..u16::MAX);
     manager
-        .start_listener(TransportType::Tcp, format!("127.0.0.1:{port}").parse().unwrap())
+        .start_listener(
+            TransportType::Tcp,
+            format!("127.0.0.1:{port}").parse().unwrap(),
+        )
         .unwrap();
 
     std::thread::sleep(std::time::Duration::from_millis(500));
@@ -487,7 +508,10 @@ fn max_message_size() {
     let mut manager = handle.join().unwrap();
 
     manager
-        .stop_listener(TransportType::Tcp, format!("127.0.0.1:{port}").parse().unwrap())
+        .stop_listener(
+            TransportType::Tcp,
+            format!("127.0.0.1:{port}").parse().unwrap(),
+        )
         .unwrap();
 }
 
@@ -526,7 +550,10 @@ fn send_timeout() {
 
     let port = get_tcp_port(10000..u16::MAX);
     manager
-        .start_listener(TransportType::Tcp, format!("127.0.0.1:{port}").parse().unwrap())
+        .start_listener(
+            TransportType::Tcp,
+            format!("127.0.0.1:{port}").parse().unwrap(),
+        )
         .unwrap();
 
     std::thread::sleep(std::time::Duration::from_millis(500));
@@ -565,7 +592,10 @@ fn send_timeout() {
     }
 
     manager
-        .stop_listener(TransportType::Tcp, format!("127.0.0.1:{port}").parse().unwrap())
+        .stop_listener(
+            TransportType::Tcp,
+            format!("127.0.0.1:{port}").parse().unwrap(),
+        )
         .unwrap();
 }
 

--- a/tests/limits.rs
+++ b/tests/limits.rs
@@ -20,6 +20,8 @@ use std::{
 
 use util::{DefaultContext, DefaultMessagesHandler, DefaultPeerId};
 
+use crate::util::get_tcp_port;
+
 #[derive(Clone)]
 pub struct DefaultInitConnection;
 impl InitConnectionHandler<DefaultPeerId, DefaultContext, DefaultMessagesHandler>
@@ -69,8 +71,9 @@ fn check_multiple_connection_refused() {
         DefaultMessagesHandler,
     > = PeerNetManager::new(config);
 
+    let port = get_tcp_port(10000..u16::MAX);
     manager
-        .start_listener(TransportType::Tcp, "127.0.0.1:8081".parse().unwrap())
+        .start_listener(TransportType::Tcp, format!("127.0.0.1:{port}").parse().unwrap())
         .unwrap();
 
     let context2 = DefaultContext {
@@ -105,7 +108,7 @@ fn check_multiple_connection_refused() {
     manager2
         .try_connect(
             TransportType::Tcp,
-            "127.0.0.1:8081".parse().unwrap(),
+            format!("127.0.0.1:{port}").parse().unwrap(),
             Duration::from_secs(3),
         )
         .unwrap();
@@ -142,7 +145,7 @@ fn check_multiple_connection_refused() {
     manager3
         .try_connect(
             TransportType::Tcp,
-            "127.0.0.1:8081".parse().unwrap(),
+            format!("127.0.0.1:{port}").parse().unwrap(),
             Duration::from_secs(3),
         )
         .unwrap();
@@ -150,7 +153,7 @@ fn check_multiple_connection_refused() {
 
     assert_eq!(manager.nb_in_connections(), 1);
     manager
-        .stop_listener(TransportType::Tcp, "127.0.0.1:8081".parse().unwrap())
+        .stop_listener(TransportType::Tcp, format!("127.0.0.1:{port}").parse().unwrap())
         .unwrap();
 }
 
@@ -185,8 +188,9 @@ fn check_too_much_in_refuse() {
         DefaultMessagesHandler,
     > = PeerNetManager::new(config);
 
+    let port = get_tcp_port(10000..u16::MAX);
     manager
-        .start_listener(TransportType::Tcp, "127.0.0.1:8080".parse().unwrap())
+        .start_listener(TransportType::Tcp, format!("127.0.0.1:{port}").parse().unwrap())
         .unwrap();
 
     let context2 = DefaultContext {
@@ -221,7 +225,7 @@ fn check_too_much_in_refuse() {
     manager2
         .try_connect(
             TransportType::Tcp,
-            "127.0.0.1:8080".parse().unwrap(),
+            format!("127.0.0.1:{port}").parse().unwrap(),
             Duration::from_secs(3),
         )
         .unwrap();
@@ -259,7 +263,7 @@ fn check_too_much_in_refuse() {
     manager3
         .try_connect(
             TransportType::Tcp,
-            "127.0.0.1:8080".parse().unwrap(),
+            format!("127.0.0.1:{port}").parse().unwrap(),
             Duration::from_secs(3),
         )
         .unwrap();
@@ -267,7 +271,7 @@ fn check_too_much_in_refuse() {
 
     assert_eq!(manager.nb_in_connections(), 1);
     manager
-        .stop_listener(TransportType::Tcp, "127.0.0.1:8080".parse().unwrap())
+        .stop_listener(TransportType::Tcp, format!("127.0.0.1:{port}").parse().unwrap())
         .unwrap();
 }
 
@@ -314,8 +318,9 @@ fn check_multiple_connection_refused_in_category() {
         DefaultInitConnection,
         DefaultMessagesHandler,
     > = PeerNetManager::new(config);
+    let port = get_tcp_port(10000..u16::MAX);
     manager
-        .start_listener(TransportType::Tcp, "127.0.0.1:8082".parse().unwrap())
+        .start_listener(TransportType::Tcp, format!("127.0.0.1:{port}").parse().unwrap())
         .unwrap();
 
     let context2 = DefaultContext {
@@ -350,7 +355,7 @@ fn check_multiple_connection_refused_in_category() {
     manager2
         .try_connect(
             TransportType::Tcp,
-            "127.0.0.1:8082".parse().unwrap(),
+            format!("127.0.0.1:{port}").parse().unwrap(),
             Duration::from_secs(3),
         )
         .unwrap();
@@ -388,7 +393,7 @@ fn check_multiple_connection_refused_in_category() {
     manager3
         .try_connect(
             TransportType::Tcp,
-            "127.0.0.1:8082".parse().unwrap(),
+            format!("127.0.0.1:{port}").parse().unwrap(),
             Duration::from_secs(3),
         )
         .unwrap();
@@ -396,7 +401,7 @@ fn check_multiple_connection_refused_in_category() {
 
     assert_eq!(manager.nb_in_connections(), 1);
     manager
-        .stop_listener(TransportType::Tcp, "127.0.0.1:8082".parse().unwrap())
+        .stop_listener(TransportType::Tcp, format!("127.0.0.1:{port}").parse().unwrap())
         .unwrap();
 }
 
@@ -433,12 +438,13 @@ fn max_message_size() {
         DefaultMessagesHandler,
     > = PeerNetManager::new(config);
 
+    let port = get_tcp_port(10000..u16::MAX);
     manager
-        .start_listener(TransportType::Tcp, "127.0.0.1:18084".parse().unwrap())
+        .start_listener(TransportType::Tcp, format!("127.0.0.1:{port}").parse().unwrap())
         .unwrap();
 
     std::thread::sleep(std::time::Duration::from_millis(500));
-    let addr: SocketAddr = "127.0.0.1:18084".parse().unwrap();
+    let addr: SocketAddr = format!("127.0.0.1:{port}").parse().unwrap();
     let stream = std::net::TcpStream::connect(addr).unwrap();
 
     let mut endpoint = Endpoint::Tcp(TcpEndpoint {
@@ -450,7 +456,7 @@ fn max_message_size() {
             max_message_size: 10,
         }
         .into(),
-        address: "127.0.0.1:18084".parse().unwrap(),
+        address: format!("127.0.0.1:{port}").parse().unwrap(),
         stream,
         total_bytes_received: Arc::new(RwLock::new(0)),
         total_bytes_sent: Arc::new(RwLock::new(0)),
@@ -481,7 +487,7 @@ fn max_message_size() {
     let mut manager = handle.join().unwrap();
 
     manager
-        .stop_listener(TransportType::Tcp, "127.0.0.1:18084".parse().unwrap())
+        .stop_listener(TransportType::Tcp, format!("127.0.0.1:{port}").parse().unwrap())
         .unwrap();
 }
 
@@ -518,14 +524,15 @@ fn send_timeout() {
         DefaultMessagesHandler,
     > = PeerNetManager::new(config);
 
+    let port = get_tcp_port(10000..u16::MAX);
     manager
-        .start_listener(TransportType::Tcp, "127.0.0.1:18085".parse().unwrap())
+        .start_listener(TransportType::Tcp, format!("127.0.0.1:{port}").parse().unwrap())
         .unwrap();
 
     std::thread::sleep(std::time::Duration::from_millis(500));
 
     // add connection to the manager
-    let addr: SocketAddr = "127.0.0.1:18085".parse().unwrap();
+    let addr: SocketAddr = format!("127.0.0.1:{port}").parse().unwrap();
     let stream = std::net::TcpStream::connect(addr).unwrap();
     let _endpoint = Endpoint::Tcp(TcpEndpoint {
         config: TcpConnectionConfig {
@@ -536,7 +543,7 @@ fn send_timeout() {
             max_message_size: 9000000,
         }
         .into(),
-        address: "127.0.0.1:18085".parse().unwrap(),
+        address: format!("127.0.0.1:{port}").parse().unwrap(),
         stream,
         total_bytes_received: Arc::new(RwLock::new(0)),
         total_bytes_sent: Arc::new(RwLock::new(0)),
@@ -558,7 +565,7 @@ fn send_timeout() {
     }
 
     manager
-        .stop_listener(TransportType::Tcp, "127.0.0.1:18085".parse().unwrap())
+        .stop_listener(TransportType::Tcp, format!("127.0.0.1:{port}").parse().unwrap())
         .unwrap();
 }
 

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -14,7 +14,7 @@ use std::net::IpAddr;
 use std::str::FromStr;
 use util::{create_clients, DefaultMessagesHandler};
 
-use crate::util::{DefaultContext, DefaultPeerId};
+use crate::util::{DefaultContext, DefaultPeerId, get_tcp_port};
 
 #[derive(Clone)]
 pub struct DefaultInitConnection;
@@ -65,20 +65,21 @@ fn simple() {
         DefaultMessagesHandler,
     > = PeerNetManager::new(config);
 
+    let port = get_tcp_port(10000..u16::MAX);
     manager
-        .start_listener(TransportType::Tcp, "127.0.0.1:64850".parse().unwrap())
+        .start_listener(TransportType::Tcp, format!("127.0.0.1:{port}").parse().unwrap())
         .unwrap();
 
-    //manager.start_listener(TransportType::Quic, "127.0.0.1:64850".parse().unwrap()).unwrap();
+    //manager.start_listener(TransportType::Quic, format!("127.0.0.1:{port}").parse().unwrap()).unwrap();
     sleep(Duration::from_secs(3));
-    let _ = create_clients(11, "127.0.0.1:64850");
+    let _ = create_clients(11, format!("127.0.0.1:{port}").as_str());
     sleep(Duration::from_secs(6));
 
     // we have max_in_connections = 10
     assert_eq!(manager.nb_in_connections(), 10);
 
     manager
-        .stop_listener(TransportType::Tcp, "127.0.0.1:64850".parse().unwrap())
+        .stop_listener(TransportType::Tcp, format!("127.0.0.1:{port}").parse().unwrap())
         .unwrap();
 }
 
@@ -114,19 +115,20 @@ fn simple_no_place() {
         DefaultMessagesHandler,
     > = PeerNetManager::new(config);
 
+    let port = get_tcp_port(10000..u16::MAX);
     manager
-        .start_listener(TransportType::Tcp, "127.0.0.1:64851".parse().unwrap())
+        .start_listener(TransportType::Tcp, format!("127.0.0.1:{port}").parse().unwrap())
         .unwrap();
-    //manager.start_listener(TransportType::Quic, "127.0.0.1:64850".parse().unwrap()).unwrap();
+    //manager.start_listener(TransportType::Quic, format!("127.0.0.1:{port}").parse().unwrap()).unwrap();
     sleep(Duration::from_secs(3));
-    let _ = create_clients(11, "127.0.0.1:64851");
+    let _ = create_clients(11, format!("127.0.0.1:{port}").as_str());
     sleep(Duration::from_secs(6));
 
     // we have max_in_connections = 10
     assert_eq!(manager.nb_in_connections(), 0);
 
     manager
-        .stop_listener(TransportType::Tcp, "127.0.0.1:64851".parse().unwrap())
+        .stop_listener(TransportType::Tcp, format!("127.0.0.1:{port}").parse().unwrap())
         .unwrap();
 }
 
@@ -162,19 +164,20 @@ fn simple_no_place_after_handshake() {
         DefaultMessagesHandler,
     > = PeerNetManager::new(config);
 
+    let port = get_tcp_port(10000..u16::MAX);
     manager
-        .start_listener(TransportType::Tcp, "127.0.0.1:64852".parse().unwrap())
+        .start_listener(TransportType::Tcp, format!("127.0.0.1:{port}").parse().unwrap())
         .unwrap();
-    //manager.start_listener(TransportType::Quic, "127.0.0.1:64850".parse().unwrap()).unwrap();
+    //manager.start_listener(TransportType::Quic, format!("127.0.0.1:{port}").parse().unwrap()).unwrap();
     sleep(Duration::from_secs(3));
-    let _ = create_clients(11, "127.0.0.1:64852");
+    let _ = create_clients(11, format!("127.0.0.1:{port}").as_str());
     sleep(Duration::from_secs(6));
 
     // we have max_in_connections = 10
     assert_eq!(manager.nb_in_connections(), 0);
 
     manager
-        .stop_listener(TransportType::Tcp, "127.0.0.1:64852".parse().unwrap())
+        .stop_listener(TransportType::Tcp, format!("127.0.0.1:{port}").parse().unwrap())
         .unwrap();
 }
 
@@ -272,19 +275,20 @@ fn simple_with_category() {
         DefaultMessagesHandler,
     > = PeerNetManager::new(config);
 
+    let port = get_tcp_port(10000..u16::MAX);
     manager
-        .start_listener(TransportType::Tcp, "127.0.0.1:64859".parse().unwrap())
+        .start_listener(TransportType::Tcp, format!("127.0.0.1:{port}").parse().unwrap())
         .unwrap();
-    //manager.start_listener(TransportType::Quic, "127.0.0.1:64850".parse().unwrap()).unwrap();
+    //manager.start_listener(TransportType::Quic, format!("127.0.0.1:{port}").parse().unwrap()).unwrap();
     sleep(Duration::from_secs(3));
-    let _ = create_clients(11, "127.0.0.1:64859");
+    let _ = create_clients(11, format!("127.0.0.1:{port}").as_str());
     sleep(Duration::from_secs(6));
 
     // we have max_in_connections = 10
     assert_eq!(manager.nb_in_connections(), 10);
 
     manager
-        .stop_listener(TransportType::Tcp, "127.0.0.1:64859".parse().unwrap())
+        .stop_listener(TransportType::Tcp, format!("127.0.0.1:{port}").parse().unwrap())
         .unwrap();
 }
 
@@ -321,8 +325,9 @@ fn two_peers_tcp() {
         DefaultMessagesHandler,
     > = PeerNetManager::new(config);
 
+    let port = get_tcp_port(10000..u16::MAX);
     manager
-        .start_listener(TransportType::Tcp, "127.0.0.1:8081".parse().unwrap())
+        .start_listener(TransportType::Tcp, format!("127.0.0.1:{port}").parse().unwrap())
         .unwrap();
 
     let context2 = DefaultContext {
@@ -360,14 +365,14 @@ fn two_peers_tcp() {
     manager2
         .try_connect(
             TransportType::Tcp,
-            "127.0.0.1:8081".parse().unwrap(),
+            format!("127.0.0.1:{port}").parse().unwrap(),
             Duration::from_secs(3),
         )
         .unwrap();
     std::thread::sleep(std::time::Duration::from_secs(1));
     assert!(manager.nb_in_connections().eq(&1));
     manager
-        .stop_listener(TransportType::Tcp, "127.0.0.1:8081".parse().unwrap())
+        .stop_listener(TransportType::Tcp, format!("127.0.0.1:{port}").parse().unwrap())
         .unwrap();
 }
 

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -14,7 +14,7 @@ use std::net::IpAddr;
 use std::str::FromStr;
 use util::{create_clients, DefaultMessagesHandler};
 
-use crate::util::{DefaultContext, DefaultPeerId, get_tcp_port};
+use crate::util::{get_tcp_port, DefaultContext, DefaultPeerId};
 
 #[derive(Clone)]
 pub struct DefaultInitConnection;
@@ -67,7 +67,10 @@ fn simple() {
 
     let port = get_tcp_port(10000..u16::MAX);
     manager
-        .start_listener(TransportType::Tcp, format!("127.0.0.1:{port}").parse().unwrap())
+        .start_listener(
+            TransportType::Tcp,
+            format!("127.0.0.1:{port}").parse().unwrap(),
+        )
         .unwrap();
 
     //manager.start_listener(TransportType::Quic, format!("127.0.0.1:{port}").parse().unwrap()).unwrap();
@@ -79,7 +82,10 @@ fn simple() {
     assert_eq!(manager.nb_in_connections(), 10);
 
     manager
-        .stop_listener(TransportType::Tcp, format!("127.0.0.1:{port}").parse().unwrap())
+        .stop_listener(
+            TransportType::Tcp,
+            format!("127.0.0.1:{port}").parse().unwrap(),
+        )
         .unwrap();
 }
 
@@ -117,7 +123,10 @@ fn simple_no_place() {
 
     let port = get_tcp_port(10000..u16::MAX);
     manager
-        .start_listener(TransportType::Tcp, format!("127.0.0.1:{port}").parse().unwrap())
+        .start_listener(
+            TransportType::Tcp,
+            format!("127.0.0.1:{port}").parse().unwrap(),
+        )
         .unwrap();
     //manager.start_listener(TransportType::Quic, format!("127.0.0.1:{port}").parse().unwrap()).unwrap();
     sleep(Duration::from_secs(3));
@@ -128,7 +137,10 @@ fn simple_no_place() {
     assert_eq!(manager.nb_in_connections(), 0);
 
     manager
-        .stop_listener(TransportType::Tcp, format!("127.0.0.1:{port}").parse().unwrap())
+        .stop_listener(
+            TransportType::Tcp,
+            format!("127.0.0.1:{port}").parse().unwrap(),
+        )
         .unwrap();
 }
 
@@ -166,7 +178,10 @@ fn simple_no_place_after_handshake() {
 
     let port = get_tcp_port(10000..u16::MAX);
     manager
-        .start_listener(TransportType::Tcp, format!("127.0.0.1:{port}").parse().unwrap())
+        .start_listener(
+            TransportType::Tcp,
+            format!("127.0.0.1:{port}").parse().unwrap(),
+        )
         .unwrap();
     //manager.start_listener(TransportType::Quic, format!("127.0.0.1:{port}").parse().unwrap()).unwrap();
     sleep(Duration::from_secs(3));
@@ -177,7 +192,10 @@ fn simple_no_place_after_handshake() {
     assert_eq!(manager.nb_in_connections(), 0);
 
     manager
-        .stop_listener(TransportType::Tcp, format!("127.0.0.1:{port}").parse().unwrap())
+        .stop_listener(
+            TransportType::Tcp,
+            format!("127.0.0.1:{port}").parse().unwrap(),
+        )
         .unwrap();
 }
 
@@ -277,7 +295,10 @@ fn simple_with_category() {
 
     let port = get_tcp_port(10000..u16::MAX);
     manager
-        .start_listener(TransportType::Tcp, format!("127.0.0.1:{port}").parse().unwrap())
+        .start_listener(
+            TransportType::Tcp,
+            format!("127.0.0.1:{port}").parse().unwrap(),
+        )
         .unwrap();
     //manager.start_listener(TransportType::Quic, format!("127.0.0.1:{port}").parse().unwrap()).unwrap();
     sleep(Duration::from_secs(3));
@@ -288,7 +309,10 @@ fn simple_with_category() {
     assert_eq!(manager.nb_in_connections(), 10);
 
     manager
-        .stop_listener(TransportType::Tcp, format!("127.0.0.1:{port}").parse().unwrap())
+        .stop_listener(
+            TransportType::Tcp,
+            format!("127.0.0.1:{port}").parse().unwrap(),
+        )
         .unwrap();
 }
 
@@ -327,7 +351,10 @@ fn two_peers_tcp() {
 
     let port = get_tcp_port(10000..u16::MAX);
     manager
-        .start_listener(TransportType::Tcp, format!("127.0.0.1:{port}").parse().unwrap())
+        .start_listener(
+            TransportType::Tcp,
+            format!("127.0.0.1:{port}").parse().unwrap(),
+        )
         .unwrap();
 
     let context2 = DefaultContext {
@@ -372,7 +399,10 @@ fn two_peers_tcp() {
     std::thread::sleep(std::time::Duration::from_secs(1));
     assert!(manager.nb_in_connections().eq(&1));
     manager
-        .stop_listener(TransportType::Tcp, format!("127.0.0.1:{port}").parse().unwrap())
+        .stop_listener(
+            TransportType::Tcp,
+            format!("127.0.0.1:{port}").parse().unwrap(),
+        )
         .unwrap();
 }
 

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -1,8 +1,8 @@
 #![allow(dead_code)]
-use std::{
-    thread::{sleep, JoinHandle},
-    time::Duration,
-};
+use std::thread::{sleep, JoinHandle};
+use std::time::Duration;
+use std::ops::Range;
+use std::net::TcpListener;
 
 use peernet::{context::Context, error::PeerNetResult, messages::MessagesHandler, peer_id::PeerId};
 use rand::Rng;
@@ -56,4 +56,15 @@ pub fn create_clients(nb_clients: usize, to_ip: &str) -> Vec<JoinHandle<()>> {
         clients.push(client);
     }
     clients
+}
+
+pub fn get_tcp_port(range:  Range<u16>) -> u16 {
+    let mut rng = rand::thread_rng();
+    loop {
+        let port = rng.gen_range(range.clone());
+        if TcpListener::bind(("127.0.0.1", port)).is_ok() {
+            return port;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
 }

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -1,8 +1,8 @@
 #![allow(dead_code)]
+use std::net::TcpListener;
+use std::ops::Range;
 use std::thread::{sleep, JoinHandle};
 use std::time::Duration;
-use std::ops::Range;
-use std::net::TcpListener;
 
 use peernet::{context::Context, error::PeerNetResult, messages::MessagesHandler, peer_id::PeerId};
 use rand::Rng;
@@ -58,7 +58,7 @@ pub fn create_clients(nb_clients: usize, to_ip: &str) -> Vec<JoinHandle<()>> {
     clients
 }
 
-pub fn get_tcp_port(range:  Range<u16>) -> u16 {
+pub fn get_tcp_port(range: Range<u16>) -> u16 {
     let mut rng = rand::thread_rng();
     loop {
         let port = rng.gen_range(range.clone());


### PR DESCRIPTION
I've had a lot of issues when running tests sometimes because of the hard-coded TCP ports being already used

This patch will choose a random TCP port whose available.

This should hopefully improve the CI as well, as some of the problems occurring were because of this issue

Note that the `doctest` is a bit more verbose and I don't really like it, but at the same time I really think it's the best to ensure we never run into this kind of very annoying problem anymore (especially with the CI)