### PR TITLE
Add addr to connection_queue on `try_connect`, use HashSet instead of Vec

### DIFF
--- a/src/network_manager.rs
+++ b/src/network_manager.rs
@@ -2,6 +2,7 @@
 //!
 //! It is the entry point of the library and is used to create and manage the transports and the peers.
 
+use std::collections::HashSet;
 use std::net::IpAddr;
 use std::thread::JoinHandle;
 use std::{collections::HashMap, net::SocketAddr, sync::Arc};
@@ -29,7 +30,7 @@ pub struct ActiveConnections<Id: PeerId> {
     pub nb_in_connections: usize,
     pub nb_out_connections: usize,
     /// Peers attempting to connect but not yet finished initialization
-    pub connection_queue: Vec<(SocketAddr, Option<String>)>,
+    pub connection_queue: HashSet<SocketAddr>,
     pub connections: HashMap<Id, PeerConnection>,
     pub listeners: HashMap<SocketAddr, TransportType>,
 }
@@ -201,7 +202,7 @@ impl<
         let active_connections = Arc::new(RwLock::new(ActiveConnections {
             nb_out_connections: 0,
             nb_in_connections: 0,
-            connection_queue: vec![],
+            connection_queue: HashSet::new(),
             connections: Default::default(),
             listeners: Default::default(),
         }));

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -163,7 +163,7 @@ pub(crate) fn new_peer<
                     let mut write_active_connections = active_connections.write();
                     write_active_connections
                         .connection_queue
-                        .retain(|(addr, _)| addr != endpoint.get_target_addr());
+                        .retain(|addr| addr != endpoint.get_target_addr());
                     write_active_connections.compute_counters();
                 }
                 return;
@@ -183,7 +183,7 @@ pub(crate) fn new_peer<
                     let mut write_active_connections = active_connections.write();
                     write_active_connections
                     .connection_queue
-                    .retain(|(addr, _)| addr != endpoint.get_target_addr());
+                    .retain(|addr| addr != endpoint.get_target_addr());
                     write_active_connections.remove_connection(&peer_id);
                 }
                 return;
@@ -195,7 +195,7 @@ pub(crate) fn new_peer<
 
             let mut write_active_connections = active_connections.write();
             write_active_connections.connection_queue
-            .retain(|(addr, _)| addr != endpoint.get_target_addr());
+            .retain(|addr| addr != endpoint.get_target_addr());
             // if peer_id == PeerId::from_public_key(self_keypair.get_public_key()) || !active_connections.write().confirm_connection(
             if peer_id == id || !write_active_connections.confirm_connection(
                 peer_id.clone(),

--- a/src/transports/tcp.rs
+++ b/src/transports/tcp.rs
@@ -298,7 +298,7 @@ impl<Id: PeerId> Transport<Id> for TcpTransport<Id> {
                                         ) {
                                             active_connections
                                                 .connection_queue
-                                                .push((address, category_name.clone()));
+                                                .insert(address);
                                             active_connections.compute_counters();
                                             None
                                         } else {
@@ -370,6 +370,7 @@ impl<Id: PeerId> Transport<Id> for TcpTransport<Id> {
                 let total_bytes_sent = self.total_bytes_sent.clone();
                 let wg = self.out_connection_attempts.clone();
                 move || {
+                    active_connections.write().connection_queue.insert(address);
                     let stream = TcpStream::connect_timeout(&address, timeout).map_err(|err| {
                         log::error!("try_connect stream connect: {err:?}");
                         TcpError::ConnectionError.wrap().new(


### PR DESCRIPTION
Related to https://github.com/massalabs/massa/pull/4243

When performing a `try_connect` (out) or when getting a peer from the listener (in), insert in both cases the address in `connection_queue` (whatever the category is).
Allows the protocol worker to check if a peer is already known before performing an operation (in or out)