### PR TITLE
Fix listener mio event handling

### DIFF
--- a/src/transports/tcp.rs
+++ b/src/transports/tcp.rs
@@ -237,7 +237,9 @@ impl<Id: PeerId> Transport<Id> for TcpTransport<Id> {
                                     loop {
                                         let (stream, address) = match server.accept() {
                                             Ok((mut stream, address)) => {
-                                                let _ = poll.registry().deregister(&mut stream);
+                                                if let Err(e) = poll.registry().deregister(&mut stream) {
+                                                    log::error!("Could not deregister the stream {:?} from the mio poll: {:?}", stream, e);
+                                                };
                                                 let stream: std::net::TcpStream = mio_stream_to_std(stream);
                                                 (stream, address)
                                             },

--- a/src/transports/tcp.rs
+++ b/src/transports/tcp.rs
@@ -212,19 +212,19 @@ impl<Id: PeerId> Transport<Id> for TcpTransport<Id> {
                 let peer_stop_tx = self.peer_stop_tx.clone();
                 let config = self.config.clone();
                 move || {
-                    let server = TcpListener::bind(address).unwrap_or_else(|_| {
+                    let std_server = TcpListener::bind(address).unwrap_or_else(|_| {
                         panic!("Can't bind TCP transport to address {}", address)
                     });
-                    server.set_nonblocking(true).unwrap_or_else(|_| {
+                    std_server.set_nonblocking(true).unwrap_or_else(|_| {
                         panic!("Can't set TCP transport to non-blocking mode for address {}", address)
                     });
-                    let mut mio_server = MioTcpListener::from_std(
-                        server.try_clone().expect("Unable to clone server socket"),
+                    let mut server = MioTcpListener::from_std(
+                        std_server.try_clone().expect("Unable to clone server socket"),
                     );
 
                     // Start listening for incoming connections.
                     poll.registry()
-                        .register(&mut mio_server, NEW_CONNECTION, Interest::READABLE)
+                        .register(&mut server, NEW_CONNECTION, Interest::READABLE)
                         .unwrap_or_else(|_| {
                             panic!(
                                 "Can't register polling on TCP transport of address {}",
@@ -242,7 +242,11 @@ impl<Id: PeerId> Transport<Id> for TcpTransport<Id> {
                                 NEW_CONNECTION => {
                                     loop {
                                         let (stream, address) = match server.accept() {
-                                            Ok((stream, address)) => (stream, address),
+                                            Ok((mut stream, address)) => {
+                                                let _ = poll.registry().deregister(&mut stream);
+                                                let stream: std::net::TcpStream = mio_stream_to_std(stream);
+                                                (stream, address)
+                                            },
                                             Err(e) if e.kind() == ErrorKind::WouldBlock => {
                                                 break;
                                             }
@@ -251,6 +255,7 @@ impl<Id: PeerId> Transport<Id> for TcpTransport<Id> {
                                                 continue;
                                             }
                                         };
+                                        
                                         {
                                             let read_active_connections = active_connections.read();
                                             let total_in_connections = read_active_connections
@@ -678,4 +683,26 @@ fn write_exact_timeout(
     }
 
     Ok(start_time.elapsed())
+}
+
+/// Convert a mio stream to std
+/// Adapted from Tokio
+pub(crate) fn mio_stream_to_std(mio_socket: mio::net::TcpStream) -> std::net::TcpStream {
+    #[cfg(unix)]
+    {
+        use std::os::unix::io::{FromRawFd, IntoRawFd};
+        unsafe { std::net::TcpStream::from_raw_fd(mio_socket.into_raw_fd()) }
+    }
+
+    #[cfg(windows)]
+    {
+        use std::os::windows::io::{FromRawSocket, IntoRawSocket};
+        unsafe { std::net::TcpStream::from_raw_socket(mio_socket.into_raw_socket()) }
+    }
+
+    #[cfg(target_os = "wasi")]
+    {
+        use std::os::wasi::io::{FromRawFd, IntoRawFd};
+        unsafe { std::net::TcpStream::from_raw_fd(io.into_raw_fd()) }
+    }
 }


### PR DESCRIPTION
Handled it the same as https://github.com/massalabs/massa/pull/4334, except I didn't use socket2 to set the flag IPV6_V6ONLY. I'm not sure it's needed here, we seem to never have issues about this?